### PR TITLE
Various souffle related improvements 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+**/.stack-work/

--- a/external-stg-compiler/cbits/ext-stg-liveness.cpp
+++ b/external-stg-compiler/cbits/ext-stg-liveness.cpp
@@ -1,1186 +1,824 @@
+
 #include "souffle/CompiledSouffle.h"
 
-extern "C" {}
+extern "C" {
+}
 
 namespace souffle {
-using namespace ram;
-struct t_btree_2__0_1__1__3 {
-  using t_tuple = Tuple<RamDomain, 2>;
-  using t_ind_0 = btree_set<t_tuple, index_utils::comparator<0, 1>>;
-  t_ind_0 ind_0;
-  using iterator = t_ind_0::iterator;
-  struct context {
-    t_ind_0::operation_hints hints_0;
-  };
-  context createContext() { return context(); }
-  bool insert(const t_tuple &t) {
-    context h;
-    return insert(t, h);
-  }
-  bool insert(const t_tuple &t, context &h) {
-    if (ind_0.insert(t, h.hints_0)) {
-      return true;
-    } else
-      return false;
-  }
-  bool insert(const RamDomain *ramDomain) {
-    RamDomain data[2];
-    std::copy(ramDomain, ramDomain + 2, data);
-    const t_tuple &tuple = reinterpret_cast<const t_tuple &>(data);
-    context h;
-    return insert(tuple, h);
-  }
-  bool insert(RamDomain a0, RamDomain a1) {
-    RamDomain data[2] = {a0, a1};
-    return insert(data);
-  }
-  template <typename T> void insertAll(T &other) {
-    for (auto const &cur : other) {
-      insert(cur);
-    }
-  }
-  void insertAll(t_btree_2__0_1__1__3 &other) { ind_0.insertAll(other.ind_0); }
-  bool contains(const t_tuple &t, context &h) const {
-    return ind_0.contains(t, h.hints_0);
-  }
-  bool contains(const t_tuple &t) const {
-    context h;
-    return contains(t, h);
-  }
-  std::size_t size() const { return ind_0.size(); }
-  iterator find(const t_tuple &t, context &h) const {
-    return ind_0.find(t, h.hints_0);
-  }
-  iterator find(const t_tuple &t) const {
-    context h;
-    return find(t, h);
-  }
-  range<iterator> equalRange_0(const t_tuple &t, context &h) const {
-    return range<iterator>(ind_0.begin(), ind_0.end());
-  }
-  range<iterator> equalRange_0(const t_tuple &t) const {
-    return range<iterator>(ind_0.begin(), ind_0.end());
-  }
-  range<t_ind_0::iterator> equalRange_1(const t_tuple &t, context &h) const {
-    t_tuple low(t);
-    t_tuple high(t);
-    low[1] = MIN_RAM_DOMAIN;
-    high[1] = MAX_RAM_DOMAIN;
-    return make_range(ind_0.lower_bound(low, h.hints_0),
-                      ind_0.upper_bound(high, h.hints_0));
-  }
-  range<t_ind_0::iterator> equalRange_1(const t_tuple &t) const {
-    context h;
-    return equalRange_1(t, h);
-  }
-  range<t_ind_0::iterator> equalRange_3(const t_tuple &t, context &h) const {
-    auto pos = ind_0.find(t, h.hints_0);
-    auto fin = ind_0.end();
-    if (pos != fin) {
-      fin = pos;
-      ++fin;
-    }
-    return make_range(pos, fin);
-  }
-  range<t_ind_0::iterator> equalRange_3(const t_tuple &t) const {
-    context h;
-    return equalRange_3(t, h);
-  }
-  bool empty() const { return ind_0.empty(); }
-  std::vector<range<iterator>> partition() const {
-    return ind_0.getChunks(400);
-  }
-  void purge() { ind_0.clear(); }
-  iterator begin() const { return ind_0.begin(); }
-  iterator end() const { return ind_0.end(); }
-  void printHintStatistics(std::ostream &o, const std::string prefix) const {
-    const auto &stats_0 = ind_0.getHintStatistics();
-    o << prefix << "arity 2 direct b-tree index [0,1]: (hits/misses/total)\n";
-    o << prefix << "Insert: " << stats_0.inserts.getHits() << "/"
-      << stats_0.inserts.getMisses() << "/" << stats_0.inserts.getAccesses()
-      << "\n";
-    o << prefix << "Contains: " << stats_0.contains.getHits() << "/"
-      << stats_0.contains.getMisses() << "/" << stats_0.contains.getAccesses()
-      << "\n";
-    o << prefix << "Lower-bound: " << stats_0.lower_bound.getHits() << "/"
-      << stats_0.lower_bound.getMisses() << "/"
-      << stats_0.lower_bound.getAccesses() << "\n";
-    o << prefix << "Upper-bound: " << stats_0.upper_bound.getHits() << "/"
-      << stats_0.upper_bound.getMisses() << "/"
-      << stats_0.upper_bound.getAccesses() << "\n";
-  }
-};
+static const RamDomain RAM_BIT_SHIFT_MASK = RAM_DOMAIN_SIZE - 1;
 struct t_btree_1__0__1 {
-  using t_tuple = Tuple<RamDomain, 1>;
-  using t_ind_0 = btree_set<t_tuple, index_utils::comparator<0>>;
-  t_ind_0 ind_0;
-  using iterator = t_ind_0::iterator;
-  struct context {
-    t_ind_0::operation_hints hints_0;
-  };
-  context createContext() { return context(); }
-  bool insert(const t_tuple &t) {
-    context h;
-    return insert(t, h);
-  }
-  bool insert(const t_tuple &t, context &h) {
-    if (ind_0.insert(t, h.hints_0)) {
-      return true;
-    } else
-      return false;
-  }
-  bool insert(const RamDomain *ramDomain) {
-    RamDomain data[1];
-    std::copy(ramDomain, ramDomain + 1, data);
-    const t_tuple &tuple = reinterpret_cast<const t_tuple &>(data);
-    context h;
-    return insert(tuple, h);
-  }
-  bool insert(RamDomain a0) {
-    RamDomain data[1] = {a0};
-    return insert(data);
-  }
-  template <typename T> void insertAll(T &other) {
-    for (auto const &cur : other) {
-      insert(cur);
-    }
-  }
-  void insertAll(t_btree_1__0__1 &other) { ind_0.insertAll(other.ind_0); }
-  bool contains(const t_tuple &t, context &h) const {
-    return ind_0.contains(t, h.hints_0);
-  }
-  bool contains(const t_tuple &t) const {
-    context h;
-    return contains(t, h);
-  }
-  std::size_t size() const { return ind_0.size(); }
-  iterator find(const t_tuple &t, context &h) const {
-    return ind_0.find(t, h.hints_0);
-  }
-  iterator find(const t_tuple &t) const {
-    context h;
-    return find(t, h);
-  }
-  range<iterator> equalRange_0(const t_tuple &t, context &h) const {
-    return range<iterator>(ind_0.begin(), ind_0.end());
-  }
-  range<iterator> equalRange_0(const t_tuple &t) const {
-    return range<iterator>(ind_0.begin(), ind_0.end());
-  }
-  range<t_ind_0::iterator> equalRange_1(const t_tuple &t, context &h) const {
-    auto pos = ind_0.find(t, h.hints_0);
-    auto fin = ind_0.end();
-    if (pos != fin) {
-      fin = pos;
-      ++fin;
-    }
-    return make_range(pos, fin);
-  }
-  range<t_ind_0::iterator> equalRange_1(const t_tuple &t) const {
-    context h;
-    return equalRange_1(t, h);
-  }
-  bool empty() const { return ind_0.empty(); }
-  std::vector<range<iterator>> partition() const {
-    return ind_0.getChunks(400);
-  }
-  void purge() { ind_0.clear(); }
-  iterator begin() const { return ind_0.begin(); }
-  iterator end() const { return ind_0.end(); }
-  void printHintStatistics(std::ostream &o, const std::string prefix) const {
-    const auto &stats_0 = ind_0.getHintStatistics();
-    o << prefix << "arity 1 direct b-tree index [0]: (hits/misses/total)\n";
-    o << prefix << "Insert: " << stats_0.inserts.getHits() << "/"
-      << stats_0.inserts.getMisses() << "/" << stats_0.inserts.getAccesses()
-      << "\n";
-    o << prefix << "Contains: " << stats_0.contains.getHits() << "/"
-      << stats_0.contains.getMisses() << "/" << stats_0.contains.getAccesses()
-      << "\n";
-    o << prefix << "Lower-bound: " << stats_0.lower_bound.getHits() << "/"
-      << stats_0.lower_bound.getMisses() << "/"
-      << stats_0.lower_bound.getAccesses() << "\n";
-    o << prefix << "Upper-bound: " << stats_0.upper_bound.getHits() << "/"
-      << stats_0.upper_bound.getMisses() << "/"
-      << stats_0.upper_bound.getAccesses() << "\n";
-  }
+using t_tuple = Tuple<RamDomain, 1>;
+struct t_comparator_0{
+ int operator()(const t_tuple& a, const t_tuple& b) const {
+  return (a[0] < b[0]) ? -1 : ((a[0] > b[0]) ? 1 :(0));
+ }
+bool less(const t_tuple& a, const t_tuple& b) const {
+  return  a[0] < b[0];
+ }
+bool equal(const t_tuple& a, const t_tuple& b) const {
+return a[0] == b[0];
+ }
 };
-struct t_btree_2__1_0__2__3 {
-  using t_tuple = Tuple<RamDomain, 2>;
-  using t_ind_0 = btree_set<t_tuple, index_utils::comparator<1, 0>>;
-  t_ind_0 ind_0;
-  using iterator = t_ind_0::iterator;
-  struct context {
-    t_ind_0::operation_hints hints_0;
-  };
-  context createContext() { return context(); }
-  bool insert(const t_tuple &t) {
-    context h;
-    return insert(t, h);
-  }
-  bool insert(const t_tuple &t, context &h) {
-    if (ind_0.insert(t, h.hints_0)) {
-      return true;
-    } else
-      return false;
-  }
-  bool insert(const RamDomain *ramDomain) {
-    RamDomain data[2];
-    std::copy(ramDomain, ramDomain + 2, data);
-    const t_tuple &tuple = reinterpret_cast<const t_tuple &>(data);
-    context h;
-    return insert(tuple, h);
-  }
-  bool insert(RamDomain a0, RamDomain a1) {
-    RamDomain data[2] = {a0, a1};
-    return insert(data);
-  }
-  template <typename T> void insertAll(T &other) {
-    for (auto const &cur : other) {
-      insert(cur);
-    }
-  }
-  void insertAll(t_btree_2__1_0__2__3 &other) { ind_0.insertAll(other.ind_0); }
-  bool contains(const t_tuple &t, context &h) const {
-    return ind_0.contains(t, h.hints_0);
-  }
-  bool contains(const t_tuple &t) const {
-    context h;
-    return contains(t, h);
-  }
-  std::size_t size() const { return ind_0.size(); }
-  iterator find(const t_tuple &t, context &h) const {
-    return ind_0.find(t, h.hints_0);
-  }
-  iterator find(const t_tuple &t) const {
-    context h;
-    return find(t, h);
-  }
-  range<iterator> equalRange_0(const t_tuple &t, context &h) const {
-    return range<iterator>(ind_0.begin(), ind_0.end());
-  }
-  range<iterator> equalRange_0(const t_tuple &t) const {
-    return range<iterator>(ind_0.begin(), ind_0.end());
-  }
-  range<t_ind_0::iterator> equalRange_2(const t_tuple &t, context &h) const {
-    t_tuple low(t);
-    t_tuple high(t);
-    low[0] = MIN_RAM_DOMAIN;
-    high[0] = MAX_RAM_DOMAIN;
-    return make_range(ind_0.lower_bound(low, h.hints_0),
-                      ind_0.upper_bound(high, h.hints_0));
-  }
-  range<t_ind_0::iterator> equalRange_2(const t_tuple &t) const {
-    context h;
-    return equalRange_2(t, h);
-  }
-  range<t_ind_0::iterator> equalRange_3(const t_tuple &t, context &h) const {
-    auto pos = ind_0.find(t, h.hints_0);
-    auto fin = ind_0.end();
-    if (pos != fin) {
-      fin = pos;
-      ++fin;
-    }
-    return make_range(pos, fin);
-  }
-  range<t_ind_0::iterator> equalRange_3(const t_tuple &t) const {
-    context h;
-    return equalRange_3(t, h);
-  }
-  bool empty() const { return ind_0.empty(); }
-  std::vector<range<iterator>> partition() const {
-    return ind_0.getChunks(400);
-  }
-  void purge() { ind_0.clear(); }
-  iterator begin() const { return ind_0.begin(); }
-  iterator end() const { return ind_0.end(); }
-  void printHintStatistics(std::ostream &o, const std::string prefix) const {
-    const auto &stats_0 = ind_0.getHintStatistics();
-    o << prefix << "arity 2 direct b-tree index [1,0]: (hits/misses/total)\n";
-    o << prefix << "Insert: " << stats_0.inserts.getHits() << "/"
-      << stats_0.inserts.getMisses() << "/" << stats_0.inserts.getAccesses()
-      << "\n";
-    o << prefix << "Contains: " << stats_0.contains.getHits() << "/"
-      << stats_0.contains.getMisses() << "/" << stats_0.contains.getAccesses()
-      << "\n";
-    o << prefix << "Lower-bound: " << stats_0.lower_bound.getHits() << "/"
-      << stats_0.lower_bound.getMisses() << "/"
-      << stats_0.lower_bound.getAccesses() << "\n";
-    o << prefix << "Upper-bound: " << stats_0.upper_bound.getHits() << "/"
-      << stats_0.upper_bound.getMisses() << "/"
-      << stats_0.upper_bound.getAccesses() << "\n";
-  }
+using t_ind_0 = btree_set<t_tuple,t_comparator_0>;
+t_ind_0 ind_0;
+using iterator = t_ind_0::iterator;
+struct context {
+t_ind_0::operation_hints hints_0;
+};
+context createContext() { return context(); }
+bool insert(const t_tuple& t) {
+context h;
+return insert(t, h);
+}
+bool insert(const t_tuple& t, context& h) {
+if (ind_0.insert(t, h.hints_0)) {
+return true;
+} else return false;
+}
+bool insert(const RamDomain* ramDomain) {
+RamDomain data[1];
+std::copy(ramDomain, ramDomain + 1, data);
+const t_tuple& tuple = reinterpret_cast<const t_tuple&>(data);
+context h;
+return insert(tuple, h);
+}
+bool insert(RamDomain a0) {
+RamDomain data[1] = {a0};
+return insert(data);
+}
+bool contains(const t_tuple& t, context& h) const {
+return ind_0.contains(t, h.hints_0);
+}
+bool contains(const t_tuple& t) const {
+context h;
+return contains(t, h);
+}
+std::size_t size() const {
+return ind_0.size();
+}
+iterator find(const t_tuple& t, context& h) const {
+return ind_0.find(t, h.hints_0);
+}
+iterator find(const t_tuple& t) const {
+context h;
+return find(t, h);
+}
+range<iterator> lowerUpperRange_0(const t_tuple& lower, const t_tuple& upper, context& h) const {
+return range<iterator>(ind_0.begin(),ind_0.end());
+}
+range<iterator> lowerUpperRange_0(const t_tuple& lower, const t_tuple& upper) const {
+return range<iterator>(ind_0.begin(),ind_0.end());
+}
+range<t_ind_0::iterator> lowerUpperRange_1(const t_tuple& lower, const t_tuple& upper, context& h) const {
+auto pos = ind_0.find(lower, h.hints_0);
+auto fin = ind_0.end();
+if (pos != fin) {fin = pos; ++fin;}
+return make_range(pos, fin);
+}
+range<t_ind_0::iterator> lowerUpperRange_1(const t_tuple& lower, const t_tuple& upper) const {
+context h;
+return lowerUpperRange_1(lower,upper,h);
+}
+bool empty() const {
+return ind_0.empty();
+}
+std::vector<range<iterator>> partition() const {
+return ind_0.getChunks(400);
+}
+void purge() {
+ind_0.clear();
+}
+iterator begin() const {
+return ind_0.begin();
+}
+iterator end() const {
+return ind_0.end();
+}
+void printStatistics(std::ostream& o) const {
+o << " arity 1 direct b-tree index 0 lex-order [0]\n";
+ind_0.printStats(o);
+}
+};
+struct t_btree_2__0_1__01__11 {
+using t_tuple = Tuple<RamDomain, 2>;
+struct t_comparator_0{
+ int operator()(const t_tuple& a, const t_tuple& b) const {
+  return (a[0] < b[0]) ? -1 : ((a[0] > b[0]) ? 1 :((a[1] < b[1]) ? -1 : ((a[1] > b[1]) ? 1 :(0))));
+ }
+bool less(const t_tuple& a, const t_tuple& b) const {
+  return  a[0] < b[0]|| (a[0] == b[0] && ( a[1] < b[1]));
+ }
+bool equal(const t_tuple& a, const t_tuple& b) const {
+return a[0] == b[0]&&a[1] == b[1];
+ }
+};
+using t_ind_0 = btree_set<t_tuple,t_comparator_0>;
+t_ind_0 ind_0;
+using iterator = t_ind_0::iterator;
+struct context {
+t_ind_0::operation_hints hints_0;
+};
+context createContext() { return context(); }
+bool insert(const t_tuple& t) {
+context h;
+return insert(t, h);
+}
+bool insert(const t_tuple& t, context& h) {
+if (ind_0.insert(t, h.hints_0)) {
+return true;
+} else return false;
+}
+bool insert(const RamDomain* ramDomain) {
+RamDomain data[2];
+std::copy(ramDomain, ramDomain + 2, data);
+const t_tuple& tuple = reinterpret_cast<const t_tuple&>(data);
+context h;
+return insert(tuple, h);
+}
+bool insert(RamDomain a0,RamDomain a1) {
+RamDomain data[2] = {a0,a1};
+return insert(data);
+}
+bool contains(const t_tuple& t, context& h) const {
+return ind_0.contains(t, h.hints_0);
+}
+bool contains(const t_tuple& t) const {
+context h;
+return contains(t, h);
+}
+std::size_t size() const {
+return ind_0.size();
+}
+iterator find(const t_tuple& t, context& h) const {
+return ind_0.find(t, h.hints_0);
+}
+iterator find(const t_tuple& t) const {
+context h;
+return find(t, h);
+}
+range<iterator> lowerUpperRange_00(const t_tuple& lower, const t_tuple& upper, context& h) const {
+return range<iterator>(ind_0.begin(),ind_0.end());
+}
+range<iterator> lowerUpperRange_00(const t_tuple& lower, const t_tuple& upper) const {
+return range<iterator>(ind_0.begin(),ind_0.end());
+}
+range<t_ind_0::iterator> lowerUpperRange_01(const t_tuple& lower, const t_tuple& upper, context& h) const {
+t_tuple low(lower); t_tuple high(lower);
+low[1] = MIN_RAM_SIGNED;
+high[1] = MAX_RAM_SIGNED;
+return make_range(ind_0.lower_bound(low, h.hints_0), ind_0.upper_bound(high, h.hints_0));
+}
+range<t_ind_0::iterator> lowerUpperRange_01(const t_tuple& lower, const t_tuple& upper) const {
+context h;
+return lowerUpperRange_01(lower,upper,h);
+}
+range<t_ind_0::iterator> lowerUpperRange_11(const t_tuple& lower, const t_tuple& upper, context& h) const {
+auto pos = ind_0.find(lower, h.hints_0);
+auto fin = ind_0.end();
+if (pos != fin) {fin = pos; ++fin;}
+return make_range(pos, fin);
+}
+range<t_ind_0::iterator> lowerUpperRange_11(const t_tuple& lower, const t_tuple& upper) const {
+context h;
+return lowerUpperRange_11(lower,upper,h);
+}
+bool empty() const {
+return ind_0.empty();
+}
+std::vector<range<iterator>> partition() const {
+return ind_0.getChunks(400);
+}
+void purge() {
+ind_0.clear();
+}
+iterator begin() const {
+return ind_0.begin();
+}
+iterator end() const {
+return ind_0.end();
+}
+void printStatistics(std::ostream& o) const {
+o << " arity 2 direct b-tree index 0 lex-order [0,1]\n";
+ind_0.printStats(o);
+}
+};
+struct t_btree_2__1_0__10__11 {
+using t_tuple = Tuple<RamDomain, 2>;
+struct t_comparator_0{
+ int operator()(const t_tuple& a, const t_tuple& b) const {
+  return (a[1] < b[1]) ? -1 : ((a[1] > b[1]) ? 1 :((a[0] < b[0]) ? -1 : ((a[0] > b[0]) ? 1 :(0))));
+ }
+bool less(const t_tuple& a, const t_tuple& b) const {
+  return  a[1] < b[1]|| (a[1] == b[1] && ( a[0] < b[0]));
+ }
+bool equal(const t_tuple& a, const t_tuple& b) const {
+return a[1] == b[1]&&a[0] == b[0];
+ }
+};
+using t_ind_0 = btree_set<t_tuple,t_comparator_0>;
+t_ind_0 ind_0;
+using iterator = t_ind_0::iterator;
+struct context {
+t_ind_0::operation_hints hints_0;
+};
+context createContext() { return context(); }
+bool insert(const t_tuple& t) {
+context h;
+return insert(t, h);
+}
+bool insert(const t_tuple& t, context& h) {
+if (ind_0.insert(t, h.hints_0)) {
+return true;
+} else return false;
+}
+bool insert(const RamDomain* ramDomain) {
+RamDomain data[2];
+std::copy(ramDomain, ramDomain + 2, data);
+const t_tuple& tuple = reinterpret_cast<const t_tuple&>(data);
+context h;
+return insert(tuple, h);
+}
+bool insert(RamDomain a0,RamDomain a1) {
+RamDomain data[2] = {a0,a1};
+return insert(data);
+}
+bool contains(const t_tuple& t, context& h) const {
+return ind_0.contains(t, h.hints_0);
+}
+bool contains(const t_tuple& t) const {
+context h;
+return contains(t, h);
+}
+std::size_t size() const {
+return ind_0.size();
+}
+iterator find(const t_tuple& t, context& h) const {
+return ind_0.find(t, h.hints_0);
+}
+iterator find(const t_tuple& t) const {
+context h;
+return find(t, h);
+}
+range<iterator> lowerUpperRange_00(const t_tuple& lower, const t_tuple& upper, context& h) const {
+return range<iterator>(ind_0.begin(),ind_0.end());
+}
+range<iterator> lowerUpperRange_00(const t_tuple& lower, const t_tuple& upper) const {
+return range<iterator>(ind_0.begin(),ind_0.end());
+}
+range<t_ind_0::iterator> lowerUpperRange_10(const t_tuple& lower, const t_tuple& upper, context& h) const {
+t_tuple low(lower); t_tuple high(lower);
+low[0] = MIN_RAM_SIGNED;
+high[0] = MAX_RAM_SIGNED;
+return make_range(ind_0.lower_bound(low, h.hints_0), ind_0.upper_bound(high, h.hints_0));
+}
+range<t_ind_0::iterator> lowerUpperRange_10(const t_tuple& lower, const t_tuple& upper) const {
+context h;
+return lowerUpperRange_10(lower,upper,h);
+}
+range<t_ind_0::iterator> lowerUpperRange_11(const t_tuple& lower, const t_tuple& upper, context& h) const {
+auto pos = ind_0.find(lower, h.hints_0);
+auto fin = ind_0.end();
+if (pos != fin) {fin = pos; ++fin;}
+return make_range(pos, fin);
+}
+range<t_ind_0::iterator> lowerUpperRange_11(const t_tuple& lower, const t_tuple& upper) const {
+context h;
+return lowerUpperRange_11(lower,upper,h);
+}
+bool empty() const {
+return ind_0.empty();
+}
+std::vector<range<iterator>> partition() const {
+return ind_0.getChunks(400);
+}
+void purge() {
+ind_0.clear();
+}
+iterator begin() const {
+return ind_0.begin();
+}
+iterator end() const {
+return ind_0.end();
+}
+void printStatistics(std::ostream& o) const {
+o << " arity 2 direct b-tree index 0 lex-order [1,0]\n";
+ind_0.printStats(o);
+}
 };
 
 class Sf_ext_stg_liveness : public SouffleProgram {
 private:
-  static inline bool regex_wrapper(const std::string &pattern,
-                                   const std::string &text) {
-    bool result = false;
-    try {
-      result = std::regex_match(text, std::regex(pattern));
-    } catch (...) {
-      std::cerr << "warning: wrong pattern provided for match(\"" << pattern
-                << "\",\"" << text << "\").\n";
-    }
-    return result;
-  }
-
+static inline bool regex_wrapper(const std::string& pattern, const std::string& text) {
+   bool result = false; 
+   try { result = std::regex_match(text, std::regex(pattern)); } catch(...) { 
+     std::cerr << "warning: wrong pattern provided for match(\"" << pattern << "\",\"" << text << "\").\n";
+}
+   return result;
+}
 private:
-  static inline std::string substr_wrapper(const std::string &str, size_t idx,
-                                           size_t len) {
-    std::string result;
-    try {
-      result = str.substr(idx, len);
-    } catch (...) {
-      std::cerr << "warning: wrong index position provided by substr(\"";
-      std::cerr << str << "\"," << (int32_t)idx << "," << (int32_t)len
-                << ") functor.\n";
-    }
-    return result;
-  }
-
-private:
-  static inline RamDomain wrapper_tonumber(const std::string &str) {
-    RamDomain result = 0;
-    try {
-      result = stord(str);
-    } catch (...) {
-      std::cerr << "error: wrong string provided by to_number(\"";
-      std::cerr << str << "\") functor.\n";
-      raise(SIGFPE);
-    }
-    return result;
-  }
-
+static inline std::string substr_wrapper(const std::string& str, size_t idx, size_t len) {
+   std::string result; 
+   try { result = str.substr(idx,len); } catch(...) { 
+     std::cerr << "warning: wrong index position provided by substr(\"";
+     std::cerr << str << "\"," << (int32_t)idx << "," << (int32_t)len << ") functor.\n";
+   } return result;
+}
 public:
-  // -- initialize symbol table --
-  SymbolTable symTable; // -- Table: DataConReference
-  std::unique_ptr<t_btree_2__0_1__1__3> rel_1_DataConReference =
-      std::make_unique<t_btree_2__0_1__1__3>();
-  souffle::RelationWrapper<0, t_btree_2__0_1__1__3, Tuple<RamDomain, 2>, 2, 1>
-      wrapper_rel_1_DataConReference;
-  // -- Table: FunReference
-  std::unique_ptr<t_btree_2__0_1__1__3> rel_2_FunReference =
-      std::make_unique<t_btree_2__0_1__1__3>();
-  souffle::RelationWrapper<1, t_btree_2__0_1__1__3, Tuple<RamDomain, 2>, 2, 1>
-      wrapper_rel_2_FunReference;
-  // -- Table: LiveSource
-  std::unique_ptr<t_btree_1__0__1> rel_3_LiveSource =
-      std::make_unique<t_btree_1__0__1>();
-  souffle::RelationWrapper<2, t_btree_1__0__1, Tuple<RamDomain, 1>, 1, 1>
-      wrapper_rel_3_LiveSource;
-  // -- Table: LiveFunName
-  std::unique_ptr<t_btree_1__0__1> rel_4_LiveFunName =
-      std::make_unique<t_btree_1__0__1>();
-  souffle::RelationWrapper<3, t_btree_1__0__1, Tuple<RamDomain, 1>, 1, 1>
-      wrapper_rel_4_LiveFunName;
-  // -- Table: @delta_LiveFunName
-  std::unique_ptr<t_btree_1__0__1> rel_5_delta_LiveFunName =
-      std::make_unique<t_btree_1__0__1>();
-  // -- Table: @new_LiveFunName
-  std::unique_ptr<t_btree_1__0__1> rel_6_new_LiveFunName =
-      std::make_unique<t_btree_1__0__1>();
-  // -- Table: TyCon
-  std::unique_ptr<t_btree_2__1_0__2__3> rel_7_TyCon =
-      std::make_unique<t_btree_2__1_0__2__3>();
-  souffle::RelationWrapper<4, t_btree_2__1_0__2__3, Tuple<RamDomain, 2>, 2, 1>
-      wrapper_rel_7_TyCon;
-  // -- Table: LiveDataConName
-  std::unique_ptr<t_btree_1__0__1> rel_8_LiveDataConName =
-      std::make_unique<t_btree_1__0__1>();
-  souffle::RelationWrapper<5, t_btree_1__0__1, Tuple<RamDomain, 1>, 1, 1>
-      wrapper_rel_8_LiveDataConName;
-  // -- Table: TyConReference
-  std::unique_ptr<t_btree_2__0_1__1__3> rel_9_TyConReference =
-      std::make_unique<t_btree_2__0_1__1__3>();
-  souffle::RelationWrapper<6, t_btree_2__0_1__1__3, Tuple<RamDomain, 2>, 2, 1>
-      wrapper_rel_9_TyConReference;
-  // -- Table: LiveTyConName
-  std::unique_ptr<t_btree_1__0__1> rel_10_LiveTyConName =
-      std::make_unique<t_btree_1__0__1>();
-  souffle::RelationWrapper<7, t_btree_1__0__1, Tuple<RamDomain, 1>, 1, 1>
-      wrapper_rel_10_LiveTyConName;
-
+// -- initialize symbol table --
+SymbolTable symTable;// -- initialize record table --
+RecordTable recordTable;
+// -- Table: @delta_LiveFunName
+std::unique_ptr<t_btree_1__0__1> rel_1_delta_LiveFunName = std::make_unique<t_btree_1__0__1>();
+// -- Table: @new_LiveFunName
+std::unique_ptr<t_btree_1__0__1> rel_2_new_LiveFunName = std::make_unique<t_btree_1__0__1>();
+// -- Table: DataConReference
+std::unique_ptr<t_btree_2__0_1__01__11> rel_3_DataConReference = std::make_unique<t_btree_2__0_1__01__11>();
+souffle::RelationWrapper<0,t_btree_2__0_1__01__11,Tuple<RamDomain,2>,2,0> wrapper_rel_3_DataConReference;
+// -- Table: FunReference
+std::unique_ptr<t_btree_2__0_1__01__11> rel_4_FunReference = std::make_unique<t_btree_2__0_1__01__11>();
+souffle::RelationWrapper<1,t_btree_2__0_1__01__11,Tuple<RamDomain,2>,2,0> wrapper_rel_4_FunReference;
+// -- Table: LiveDataConName
+std::unique_ptr<t_btree_1__0__1> rel_5_LiveDataConName = std::make_unique<t_btree_1__0__1>();
+souffle::RelationWrapper<2,t_btree_1__0__1,Tuple<RamDomain,1>,1,0> wrapper_rel_5_LiveDataConName;
+// -- Table: LiveFunName
+std::unique_ptr<t_btree_1__0__1> rel_6_LiveFunName = std::make_unique<t_btree_1__0__1>();
+souffle::RelationWrapper<3,t_btree_1__0__1,Tuple<RamDomain,1>,1,0> wrapper_rel_6_LiveFunName;
+// -- Table: LiveSource
+std::unique_ptr<t_btree_1__0__1> rel_7_LiveSource = std::make_unique<t_btree_1__0__1>();
+souffle::RelationWrapper<4,t_btree_1__0__1,Tuple<RamDomain,1>,1,0> wrapper_rel_7_LiveSource;
+// -- Table: LiveTyConName
+std::unique_ptr<t_btree_1__0__1> rel_8_LiveTyConName = std::make_unique<t_btree_1__0__1>();
+souffle::RelationWrapper<5,t_btree_1__0__1,Tuple<RamDomain,1>,1,0> wrapper_rel_8_LiveTyConName;
+// -- Table: TyCon
+std::unique_ptr<t_btree_2__1_0__10__11> rel_9_TyCon = std::make_unique<t_btree_2__1_0__10__11>();
+souffle::RelationWrapper<6,t_btree_2__1_0__10__11,Tuple<RamDomain,2>,2,0> wrapper_rel_9_TyCon;
+// -- Table: TyConReference
+std::unique_ptr<t_btree_2__0_1__01__11> rel_10_TyConReference = std::make_unique<t_btree_2__0_1__01__11>();
+souffle::RelationWrapper<7,t_btree_2__0_1__01__11,Tuple<RamDomain,2>,2,0> wrapper_rel_10_TyConReference;
 public:
-  Sf_ext_stg_liveness()
-      : wrapper_rel_1_DataConReference(
-            *rel_1_DataConReference, symTable, "DataConReference",
-            std::array<const char *, 2>{{"s:Name", "s:Name"}},
-            std::array<const char *, 2>{{"fun", "datacon"}}),
+Sf_ext_stg_liveness() : 
+wrapper_rel_3_DataConReference(*rel_3_DataConReference,symTable,"DataConReference",std::array<const char *,2>{{"s:Name","s:Name"}},std::array<const char *,2>{{"fun","datacon"}}),
 
-        wrapper_rel_2_FunReference(
-            *rel_2_FunReference, symTable, "FunReference",
-            std::array<const char *, 2>{{"s:Name", "s:Name"}},
-            std::array<const char *, 2>{{"fun", "funref"}}),
+wrapper_rel_4_FunReference(*rel_4_FunReference,symTable,"FunReference",std::array<const char *,2>{{"s:Name","s:Name"}},std::array<const char *,2>{{"fun","funref"}}),
 
-        wrapper_rel_3_LiveSource(*rel_3_LiveSource, symTable, "LiveSource",
-                                 std::array<const char *, 1>{{"s:Name"}},
-                                 std::array<const char *, 1>{{"fun"}}),
+wrapper_rel_5_LiveDataConName(*rel_5_LiveDataConName,symTable,"LiveDataConName",std::array<const char *,1>{{"s:Name"}},std::array<const char *,1>{{"datacon"}}),
 
-        wrapper_rel_4_LiveFunName(*rel_4_LiveFunName, symTable, "LiveFunName",
-                                  std::array<const char *, 1>{{"s:Name"}},
-                                  std::array<const char *, 1>{{"fun"}}),
+wrapper_rel_6_LiveFunName(*rel_6_LiveFunName,symTable,"LiveFunName",std::array<const char *,1>{{"s:Name"}},std::array<const char *,1>{{"fun"}}),
 
-        wrapper_rel_7_TyCon(*rel_7_TyCon, symTable, "TyCon",
-                            std::array<const char *, 2>{{"s:Name", "s:Name"}},
-                            std::array<const char *, 2>{{"tycon", "datacon"}}),
+wrapper_rel_7_LiveSource(*rel_7_LiveSource,symTable,"LiveSource",std::array<const char *,1>{{"s:Name"}},std::array<const char *,1>{{"fun"}}),
 
-        wrapper_rel_8_LiveDataConName(*rel_8_LiveDataConName, symTable,
-                                      "LiveDataConName",
-                                      std::array<const char *, 1>{{"s:Name"}},
-                                      std::array<const char *, 1>{{"datacon"}}),
+wrapper_rel_8_LiveTyConName(*rel_8_LiveTyConName,symTable,"LiveTyConName",std::array<const char *,1>{{"s:Name"}},std::array<const char *,1>{{"tycon"}}),
 
-        wrapper_rel_9_TyConReference(
-            *rel_9_TyConReference, symTable, "TyConReference",
-            std::array<const char *, 2>{{"s:Name", "s:Name"}},
-            std::array<const char *, 2>{{"fun", "tycon"}}),
+wrapper_rel_9_TyCon(*rel_9_TyCon,symTable,"TyCon",std::array<const char *,2>{{"s:Name","s:Name"}},std::array<const char *,2>{{"tycon","datacon"}}),
 
-        wrapper_rel_10_LiveTyConName(*rel_10_LiveTyConName, symTable,
-                                     "LiveTyConName",
-                                     std::array<const char *, 1>{{"s:Name"}},
-                                     std::array<const char *, 1>{{"tycon"}}) {
-    addRelation("DataConReference", &wrapper_rel_1_DataConReference, true,
-                false);
-    addRelation("FunReference", &wrapper_rel_2_FunReference, true, false);
-    addRelation("LiveSource", &wrapper_rel_3_LiveSource, true, false);
-    addRelation("LiveFunName", &wrapper_rel_4_LiveFunName, false, true);
-    addRelation("TyCon", &wrapper_rel_7_TyCon, true, false);
-    addRelation("LiveDataConName", &wrapper_rel_8_LiveDataConName, false, true);
-    addRelation("TyConReference", &wrapper_rel_9_TyConReference, true, false);
-    addRelation("LiveTyConName", &wrapper_rel_10_LiveTyConName, false, true);
-  }
-  ~Sf_ext_stg_liveness() {}
-
+wrapper_rel_10_TyConReference(*rel_10_TyConReference,symTable,"TyConReference",std::array<const char *,2>{{"s:Name","s:Name"}},std::array<const char *,2>{{"fun","tycon"}}){
+addRelation("DataConReference",&wrapper_rel_3_DataConReference,true,false);
+addRelation("FunReference",&wrapper_rel_4_FunReference,true,false);
+addRelation("LiveDataConName",&wrapper_rel_5_LiveDataConName,false,true);
+addRelation("LiveFunName",&wrapper_rel_6_LiveFunName,false,true);
+addRelation("LiveSource",&wrapper_rel_7_LiveSource,true,false);
+addRelation("LiveTyConName",&wrapper_rel_8_LiveTyConName,false,true);
+addRelation("TyCon",&wrapper_rel_9_TyCon,true,false);
+addRelation("TyConReference",&wrapper_rel_10_TyConReference,true,false);
+}
+~Sf_ext_stg_liveness() {
+}
 private:
-  void runFunction(std::string inputDirectory = ".",
-                   std::string outputDirectory = ".",
-                   size_t stratumIndex = (size_t)-1, bool performIO = false) {
-    SignalHandler::instance()->set();
-    std::atomic<size_t> iter(0);
+std::string inputDirectory;
+std::string outputDirectory;
+bool performIO;
+std::atomic<RamDomain> ctr{};
 
+std::atomic<size_t> iter{};
+void runFunction(std::string inputDirectory = ".", std::string outputDirectory = ".", bool performIO = false) {
+this->inputDirectory = inputDirectory;
+this->outputDirectory = outputDirectory;
+this->performIO = performIO;
+SignalHandler::instance()->set();
 #if defined(_OPENMP)
-    if (getNumThreads() > 0) {
-      omp_set_num_threads(getNumThreads());
-    }
+if (getNumThreads() > 0) {omp_set_num_threads(getNumThreads());}
 #endif
 
-    // -- query evaluation --
-    /* BEGIN STRATUM 0 */
-    [&]() {
-      if (performIO) {
-        try {
-          std::map<std::string, std::string> directiveMap(
-              {{"IO", "file"},
-               {"filename", "./DataConReference.facts"},
-               {"name", "DataConReference"}});
-          if (!inputDirectory.empty() && directiveMap["IO"] == "file" &&
-              directiveMap["filename"].front() != '/') {
-            directiveMap["filename"] =
-                inputDirectory + "/" + directiveMap["filename"];
-          }
-          IODirectives ioDirectives(directiveMap);
-          IOSystem::getInstance()
-              .getReader(std::vector<bool>({1, 1}), symTable, ioDirectives,
-                         false, 1)
-              ->readAll(*rel_1_DataConReference);
-        } catch (std::exception &e) {
-          std::cerr << "Error loading data: " << e.what() << '\n';
-        }
-      }
-    }();
-    /* END STRATUM 0 */
-    /* BEGIN STRATUM 1 */
-    [&]() {
-      if (performIO) {
-        try {
-          std::map<std::string, std::string> directiveMap(
-              {{"IO", "file"},
-               {"filename", "./FunReference.facts"},
-               {"name", "FunReference"}});
-          if (!inputDirectory.empty() && directiveMap["IO"] == "file" &&
-              directiveMap["filename"].front() != '/') {
-            directiveMap["filename"] =
-                inputDirectory + "/" + directiveMap["filename"];
-          }
-          IODirectives ioDirectives(directiveMap);
-          IOSystem::getInstance()
-              .getReader(std::vector<bool>({1, 1}), symTable, ioDirectives,
-                         false, 1)
-              ->readAll(*rel_2_FunReference);
-        } catch (std::exception &e) {
-          std::cerr << "Error loading data: " << e.what() << '\n';
-        }
-      }
-    }();
-    /* END STRATUM 1 */
-    /* BEGIN STRATUM 2 */
-    [&]() {
-      if (performIO) {
-        try {
-          std::map<std::string, std::string> directiveMap(
-              {{"IO", "file"},
-               {"filename", "./LiveSource.facts"},
-               {"name", "LiveSource"}});
-          if (!inputDirectory.empty() && directiveMap["IO"] == "file" &&
-              directiveMap["filename"].front() != '/') {
-            directiveMap["filename"] =
-                inputDirectory + "/" + directiveMap["filename"];
-          }
-          IODirectives ioDirectives(directiveMap);
-          IOSystem::getInstance()
-              .getReader(std::vector<bool>({1}), symTable, ioDirectives, false,
-                         1)
-              ->readAll(*rel_3_LiveSource);
-        } catch (std::exception &e) {
-          std::cerr << "Error loading data: " << e.what() << '\n';
-        }
-      }
-    }();
-    /* END STRATUM 2 */
-    /* BEGIN STRATUM 3 */
-    [&]() {
-      SignalHandler::instance()->setMsg(R"_(LiveFunName(fun) :- 
+// -- query evaluation --
+{
+ std::vector<RamDomain> args, ret;
+subroutine_0(args, ret);
+}
+{
+ std::vector<RamDomain> args, ret;
+subroutine_1(args, ret);
+}
+{
+ std::vector<RamDomain> args, ret;
+subroutine_2(args, ret);
+}
+{
+ std::vector<RamDomain> args, ret;
+subroutine_3(args, ret);
+}
+{
+ std::vector<RamDomain> args, ret;
+subroutine_4(args, ret);
+}
+{
+ std::vector<RamDomain> args, ret;
+subroutine_5(args, ret);
+}
+{
+ std::vector<RamDomain> args, ret;
+subroutine_6(args, ret);
+}
+{
+ std::vector<RamDomain> args, ret;
+subroutine_7(args, ret);
+}
+
+// -- relation hint statistics --
+SignalHandler::instance()->reset();
+}
+public:
+void run() override { runFunction(".", ".", false); }
+public:
+void runAll(std::string inputDirectory = ".", std::string outputDirectory = ".") override { runFunction(inputDirectory, outputDirectory, true);
+}
+public:
+void printAll(std::string outputDirectory = ".") override {
+try {std::map<std::string, std::string> directiveMap({{"IO","file"},{"attributeNames","fun"},{"filename","./LiveFunName.csv"},{"name","LiveFunName"},{"operation","output"},{"types","{\"LiveFunName\": {\"arity\": 1, \"auxArity\": 0, \"types\": [\"s:Name\"]}, \"records\": {}}"}});
+if (!outputDirectory.empty() && directiveMap["IO"] == "file" && directiveMap["filename"].front() != '/') {directiveMap["filename"] = outputDirectory + "/" + directiveMap["filename"];}
+IOSystem::getInstance().getWriter(directiveMap, symTable, recordTable)->writeAll(*rel_6_LiveFunName);
+} catch (std::exception& e) {std::cerr << e.what();exit(1);}
+try {std::map<std::string, std::string> directiveMap({{"IO","file"},{"attributeNames","datacon"},{"filename","./LiveDataConName.csv"},{"name","LiveDataConName"},{"operation","output"},{"types","{\"LiveDataConName\": {\"arity\": 1, \"auxArity\": 0, \"types\": [\"s:Name\"]}, \"records\": {}}"}});
+if (!outputDirectory.empty() && directiveMap["IO"] == "file" && directiveMap["filename"].front() != '/') {directiveMap["filename"] = outputDirectory + "/" + directiveMap["filename"];}
+IOSystem::getInstance().getWriter(directiveMap, symTable, recordTable)->writeAll(*rel_5_LiveDataConName);
+} catch (std::exception& e) {std::cerr << e.what();exit(1);}
+try {std::map<std::string, std::string> directiveMap({{"IO","file"},{"attributeNames","tycon"},{"filename","./LiveTyConName.csv"},{"name","LiveTyConName"},{"operation","output"},{"types","{\"LiveTyConName\": {\"arity\": 1, \"auxArity\": 0, \"types\": [\"s:Name\"]}, \"records\": {}}"}});
+if (!outputDirectory.empty() && directiveMap["IO"] == "file" && directiveMap["filename"].front() != '/') {directiveMap["filename"] = outputDirectory + "/" + directiveMap["filename"];}
+IOSystem::getInstance().getWriter(directiveMap, symTable, recordTable)->writeAll(*rel_8_LiveTyConName);
+} catch (std::exception& e) {std::cerr << e.what();exit(1);}
+}
+public:
+void loadAll(std::string inputDirectory = ".") override {
+try {std::map<std::string, std::string> directiveMap({{"IO","file"},{"filename","./TyCon.facts"},{"name","TyCon"},{"operation","input"},{"types","{\"TyCon\": {\"arity\": 2, \"auxArity\": 0, \"types\": [\"s:Name\", \"s:Name\"]}, \"records\": {}}"}});
+if (!inputDirectory.empty() && directiveMap["IO"] == "file" && directiveMap["filename"].front() != '/') {directiveMap["filename"] = inputDirectory + "/" + directiveMap["filename"];}
+IOSystem::getInstance().getReader(directiveMap, symTable, recordTable)->readAll(*rel_9_TyCon);
+} catch (std::exception& e) {std::cerr << "Error loading data: " << e.what() << '\n';}
+try {std::map<std::string, std::string> directiveMap({{"IO","file"},{"filename","./FunReference.facts"},{"name","FunReference"},{"operation","input"},{"types","{\"FunReference\": {\"arity\": 2, \"auxArity\": 0, \"types\": [\"s:Name\", \"s:Name\"]}, \"records\": {}}"}});
+if (!inputDirectory.empty() && directiveMap["IO"] == "file" && directiveMap["filename"].front() != '/') {directiveMap["filename"] = inputDirectory + "/" + directiveMap["filename"];}
+IOSystem::getInstance().getReader(directiveMap, symTable, recordTable)->readAll(*rel_4_FunReference);
+} catch (std::exception& e) {std::cerr << "Error loading data: " << e.what() << '\n';}
+try {std::map<std::string, std::string> directiveMap({{"IO","file"},{"filename","./TyConReference.facts"},{"name","TyConReference"},{"operation","input"},{"types","{\"TyConReference\": {\"arity\": 2, \"auxArity\": 0, \"types\": [\"s:Name\", \"s:Name\"]}, \"records\": {}}"}});
+if (!inputDirectory.empty() && directiveMap["IO"] == "file" && directiveMap["filename"].front() != '/') {directiveMap["filename"] = inputDirectory + "/" + directiveMap["filename"];}
+IOSystem::getInstance().getReader(directiveMap, symTable, recordTable)->readAll(*rel_10_TyConReference);
+} catch (std::exception& e) {std::cerr << "Error loading data: " << e.what() << '\n';}
+try {std::map<std::string, std::string> directiveMap({{"IO","file"},{"filename","./DataConReference.facts"},{"name","DataConReference"},{"operation","input"},{"types","{\"DataConReference\": {\"arity\": 2, \"auxArity\": 0, \"types\": [\"s:Name\", \"s:Name\"]}, \"records\": {}}"}});
+if (!inputDirectory.empty() && directiveMap["IO"] == "file" && directiveMap["filename"].front() != '/') {directiveMap["filename"] = inputDirectory + "/" + directiveMap["filename"];}
+IOSystem::getInstance().getReader(directiveMap, symTable, recordTable)->readAll(*rel_3_DataConReference);
+} catch (std::exception& e) {std::cerr << "Error loading data: " << e.what() << '\n';}
+try {std::map<std::string, std::string> directiveMap({{"IO","file"},{"filename","./LiveSource.facts"},{"name","LiveSource"},{"operation","input"},{"types","{\"LiveSource\": {\"arity\": 1, \"auxArity\": 0, \"types\": [\"s:Name\"]}, \"records\": {}}"}});
+if (!inputDirectory.empty() && directiveMap["IO"] == "file" && directiveMap["filename"].front() != '/') {directiveMap["filename"] = inputDirectory + "/" + directiveMap["filename"];}
+IOSystem::getInstance().getReader(directiveMap, symTable, recordTable)->readAll(*rel_7_LiveSource);
+} catch (std::exception& e) {std::cerr << "Error loading data: " << e.what() << '\n';}
+}
+public:
+void dumpInputs(std::ostream& out = std::cout) override {
+try {std::map<std::string, std::string> rwOperation;
+rwOperation["IO"] = "stdout";
+rwOperation["name"] = "TyCon";
+rwOperation["types"] = "{\"TyCon\": {\"arity\": 2, \"auxArity\": 0, \"types\": [\"s:Name\", \"s:Name\"]}}";
+IOSystem::getInstance().getWriter(rwOperation, symTable, recordTable)->writeAll(*rel_9_TyCon);
+} catch (std::exception& e) {std::cerr << e.what();exit(1);}
+try {std::map<std::string, std::string> rwOperation;
+rwOperation["IO"] = "stdout";
+rwOperation["name"] = "FunReference";
+rwOperation["types"] = "{\"FunReference\": {\"arity\": 2, \"auxArity\": 0, \"types\": [\"s:Name\", \"s:Name\"]}}";
+IOSystem::getInstance().getWriter(rwOperation, symTable, recordTable)->writeAll(*rel_4_FunReference);
+} catch (std::exception& e) {std::cerr << e.what();exit(1);}
+try {std::map<std::string, std::string> rwOperation;
+rwOperation["IO"] = "stdout";
+rwOperation["name"] = "TyConReference";
+rwOperation["types"] = "{\"TyConReference\": {\"arity\": 2, \"auxArity\": 0, \"types\": [\"s:Name\", \"s:Name\"]}}";
+IOSystem::getInstance().getWriter(rwOperation, symTable, recordTable)->writeAll(*rel_10_TyConReference);
+} catch (std::exception& e) {std::cerr << e.what();exit(1);}
+try {std::map<std::string, std::string> rwOperation;
+rwOperation["IO"] = "stdout";
+rwOperation["name"] = "DataConReference";
+rwOperation["types"] = "{\"DataConReference\": {\"arity\": 2, \"auxArity\": 0, \"types\": [\"s:Name\", \"s:Name\"]}}";
+IOSystem::getInstance().getWriter(rwOperation, symTable, recordTable)->writeAll(*rel_3_DataConReference);
+} catch (std::exception& e) {std::cerr << e.what();exit(1);}
+try {std::map<std::string, std::string> rwOperation;
+rwOperation["IO"] = "stdout";
+rwOperation["name"] = "LiveSource";
+rwOperation["types"] = "{\"LiveSource\": {\"arity\": 1, \"auxArity\": 0, \"types\": [\"s:Name\"]}}";
+IOSystem::getInstance().getWriter(rwOperation, symTable, recordTable)->writeAll(*rel_7_LiveSource);
+} catch (std::exception& e) {std::cerr << e.what();exit(1);}
+}
+public:
+void dumpOutputs(std::ostream& out = std::cout) override {
+try {std::map<std::string, std::string> rwOperation;
+rwOperation["IO"] = "stdout";
+rwOperation["name"] = "LiveFunName";
+rwOperation["types"] = "{\"LiveFunName\": {\"arity\": 1, \"auxArity\": 0, \"types\": [\"s:Name\"]}}";
+IOSystem::getInstance().getWriter(rwOperation, symTable, recordTable)->writeAll(*rel_6_LiveFunName);
+} catch (std::exception& e) {std::cerr << e.what();exit(1);}
+try {std::map<std::string, std::string> rwOperation;
+rwOperation["IO"] = "stdout";
+rwOperation["name"] = "LiveDataConName";
+rwOperation["types"] = "{\"LiveDataConName\": {\"arity\": 1, \"auxArity\": 0, \"types\": [\"s:Name\"]}}";
+IOSystem::getInstance().getWriter(rwOperation, symTable, recordTable)->writeAll(*rel_5_LiveDataConName);
+} catch (std::exception& e) {std::cerr << e.what();exit(1);}
+try {std::map<std::string, std::string> rwOperation;
+rwOperation["IO"] = "stdout";
+rwOperation["name"] = "LiveTyConName";
+rwOperation["types"] = "{\"LiveTyConName\": {\"arity\": 1, \"auxArity\": 0, \"types\": [\"s:Name\"]}}";
+IOSystem::getInstance().getWriter(rwOperation, symTable, recordTable)->writeAll(*rel_8_LiveTyConName);
+} catch (std::exception& e) {std::cerr << e.what();exit(1);}
+}
+public:
+SymbolTable& getSymbolTable() override {
+return symTable;
+}
+void executeSubroutine(std::string name, const std::vector<RamDomain>& args, std::vector<RamDomain>& ret) override {
+if (name == "stratum_0") {
+subroutine_0(args, ret);
+return;}
+if (name == "stratum_1") {
+subroutine_1(args, ret);
+return;}
+if (name == "stratum_2") {
+subroutine_2(args, ret);
+return;}
+if (name == "stratum_3") {
+subroutine_3(args, ret);
+return;}
+if (name == "stratum_4") {
+subroutine_4(args, ret);
+return;}
+if (name == "stratum_5") {
+subroutine_5(args, ret);
+return;}
+if (name == "stratum_6") {
+subroutine_6(args, ret);
+return;}
+if (name == "stratum_7") {
+subroutine_7(args, ret);
+return;}
+fatal("unknown subroutine");
+}
+void subroutine_0(const std::vector<RamDomain>& args, std::vector<RamDomain>& ret) {
+if (performIO) {
+try {std::map<std::string, std::string> directiveMap({{"IO","file"},{"filename","./TyCon.facts"},{"name","TyCon"},{"operation","input"},{"types","{\"TyCon\": {\"arity\": 2, \"auxArity\": 0, \"types\": [\"s:Name\", \"s:Name\"]}, \"records\": {}}"}});
+if (!inputDirectory.empty() && directiveMap["filename"].front() != '/') {directiveMap["filename"] = inputDirectory + "/" + directiveMap["filename"];}
+IOSystem::getInstance().getReader(directiveMap, symTable, recordTable)->readAll(*rel_9_TyCon);
+} catch (std::exception& e) {std::cerr << "Error loading data: " << e.what() << '\n';}
+}
+}
+void subroutine_1(const std::vector<RamDomain>& args, std::vector<RamDomain>& ret) {
+if (performIO) {
+try {std::map<std::string, std::string> directiveMap({{"IO","file"},{"filename","./TyConReference.facts"},{"name","TyConReference"},{"operation","input"},{"types","{\"TyConReference\": {\"arity\": 2, \"auxArity\": 0, \"types\": [\"s:Name\", \"s:Name\"]}, \"records\": {}}"}});
+if (!inputDirectory.empty() && directiveMap["filename"].front() != '/') {directiveMap["filename"] = inputDirectory + "/" + directiveMap["filename"];}
+IOSystem::getInstance().getReader(directiveMap, symTable, recordTable)->readAll(*rel_10_TyConReference);
+} catch (std::exception& e) {std::cerr << "Error loading data: " << e.what() << '\n';}
+}
+}
+void subroutine_2(const std::vector<RamDomain>& args, std::vector<RamDomain>& ret) {
+if (performIO) {
+try {std::map<std::string, std::string> directiveMap({{"IO","file"},{"filename","./DataConReference.facts"},{"name","DataConReference"},{"operation","input"},{"types","{\"DataConReference\": {\"arity\": 2, \"auxArity\": 0, \"types\": [\"s:Name\", \"s:Name\"]}, \"records\": {}}"}});
+if (!inputDirectory.empty() && directiveMap["filename"].front() != '/') {directiveMap["filename"] = inputDirectory + "/" + directiveMap["filename"];}
+IOSystem::getInstance().getReader(directiveMap, symTable, recordTable)->readAll(*rel_3_DataConReference);
+} catch (std::exception& e) {std::cerr << "Error loading data: " << e.what() << '\n';}
+}
+}
+void subroutine_3(const std::vector<RamDomain>& args, std::vector<RamDomain>& ret) {
+if (performIO) {
+try {std::map<std::string, std::string> directiveMap({{"IO","file"},{"filename","./FunReference.facts"},{"name","FunReference"},{"operation","input"},{"types","{\"FunReference\": {\"arity\": 2, \"auxArity\": 0, \"types\": [\"s:Name\", \"s:Name\"]}, \"records\": {}}"}});
+if (!inputDirectory.empty() && directiveMap["filename"].front() != '/') {directiveMap["filename"] = inputDirectory + "/" + directiveMap["filename"];}
+IOSystem::getInstance().getReader(directiveMap, symTable, recordTable)->readAll(*rel_4_FunReference);
+} catch (std::exception& e) {std::cerr << "Error loading data: " << e.what() << '\n';}
+}
+}
+void subroutine_4(const std::vector<RamDomain>& args, std::vector<RamDomain>& ret) {
+if (performIO) {
+try {std::map<std::string, std::string> directiveMap({{"IO","file"},{"filename","./LiveSource.facts"},{"name","LiveSource"},{"operation","input"},{"types","{\"LiveSource\": {\"arity\": 1, \"auxArity\": 0, \"types\": [\"s:Name\"]}, \"records\": {}}"}});
+if (!inputDirectory.empty() && directiveMap["filename"].front() != '/') {directiveMap["filename"] = inputDirectory + "/" + directiveMap["filename"];}
+IOSystem::getInstance().getReader(directiveMap, symTable, recordTable)->readAll(*rel_7_LiveSource);
+} catch (std::exception& e) {std::cerr << "Error loading data: " << e.what() << '\n';}
+}
+}
+void subroutine_5(const std::vector<RamDomain>& args, std::vector<RamDomain>& ret) {
+SignalHandler::instance()->setMsg(R"_(LiveFunName(fun) :- 
    LiveSource(fun).
-in file /home/csaba/haskell/grin-compiler/ghc-whole-program-compiler-project/external-stg-compiler/datalog/ext-stg-liveness.dl [30:1-31:19])_");
-      if (!(rel_3_LiveSource->empty())) {
-        [&]() {
-          CREATE_OP_CONTEXT(rel_4_LiveFunName_op_ctxt,
-                            rel_4_LiveFunName->createContext());
-          CREATE_OP_CONTEXT(rel_3_LiveSource_op_ctxt,
-                            rel_3_LiveSource->createContext());
-          for (const auto &env0 : *rel_3_LiveSource) {
-            Tuple<RamDomain, 1> tuple{{static_cast<RamDomain>(env0[0])}};
-            rel_4_LiveFunName->insert(
-                tuple, READ_OP_CONTEXT(rel_4_LiveFunName_op_ctxt));
-          }
-        }();
-      }
-      rel_5_delta_LiveFunName->insertAll(*rel_4_LiveFunName);
-      iter = 0;
-      for (;;) {
-        SignalHandler::instance()->setMsg(R"_(LiveFunName(ref) :- 
+in file /Users/luc/personal/souffle-hs/ext-stg-liveness.dl [30:1-31:19])_");
+if(!(rel_7_LiveSource->empty())) {
+[&](){
+CREATE_OP_CONTEXT(rel_7_LiveSource_op_ctxt,rel_7_LiveSource->createContext());
+CREATE_OP_CONTEXT(rel_6_LiveFunName_op_ctxt,rel_6_LiveFunName->createContext());
+for(const auto& env0 : *rel_7_LiveSource) {
+Tuple<RamDomain,1> tuple{{ramBitCast(env0[0])}};
+rel_6_LiveFunName->insert(tuple,READ_OP_CONTEXT(rel_6_LiveFunName_op_ctxt));
+}
+}
+();}
+[&](){
+CREATE_OP_CONTEXT(rel_6_LiveFunName_op_ctxt,rel_6_LiveFunName->createContext());
+CREATE_OP_CONTEXT(rel_1_delta_LiveFunName_op_ctxt,rel_1_delta_LiveFunName->createContext());
+for(const auto& env0 : *rel_6_LiveFunName) {
+Tuple<RamDomain,1> tuple{{ramBitCast(env0[0])}};
+rel_1_delta_LiveFunName->insert(tuple,READ_OP_CONTEXT(rel_1_delta_LiveFunName_op_ctxt));
+}
+}
+();iter = 0;
+for(;;) {
+SignalHandler::instance()->setMsg(R"_(LiveFunName(ref) :- 
    LiveFunName(fun),
    FunReference(fun,ref).
-in file /home/csaba/haskell/grin-compiler/ghc-whole-program-compiler-project/external-stg-compiler/datalog/ext-stg-liveness.dl [33:1-35:26])_");
-        if (!(rel_2_FunReference->empty()) &&
-            !(rel_5_delta_LiveFunName->empty())) {
-          [&]() {
-            CREATE_OP_CONTEXT(rel_2_FunReference_op_ctxt,
-                              rel_2_FunReference->createContext());
-            CREATE_OP_CONTEXT(rel_4_LiveFunName_op_ctxt,
-                              rel_4_LiveFunName->createContext());
-            CREATE_OP_CONTEXT(rel_6_new_LiveFunName_op_ctxt,
-                              rel_6_new_LiveFunName->createContext());
-            CREATE_OP_CONTEXT(rel_5_delta_LiveFunName_op_ctxt,
-                              rel_5_delta_LiveFunName->createContext());
-            for (const auto &env0 : *rel_5_delta_LiveFunName) {
-              const Tuple<RamDomain, 2> key{{env0[0], 0}};
-              auto range = rel_2_FunReference->equalRange_1(
-                  key, READ_OP_CONTEXT(rel_2_FunReference_op_ctxt));
-              for (const auto &env1 : range) {
-                if (!(rel_4_LiveFunName->contains(
-                        Tuple<RamDomain, 1>{{env1[1]}},
-                        READ_OP_CONTEXT(rel_4_LiveFunName_op_ctxt)))) {
-                  Tuple<RamDomain, 1> tuple{{static_cast<RamDomain>(env1[1])}};
-                  rel_6_new_LiveFunName->insert(
-                      tuple, READ_OP_CONTEXT(rel_6_new_LiveFunName_op_ctxt));
-                }
-              }
-            }
-          }();
-        }
-        if (rel_6_new_LiveFunName->empty())
-          break;
-        rel_4_LiveFunName->insertAll(*rel_6_new_LiveFunName);
-        std::swap(rel_5_delta_LiveFunName, rel_6_new_LiveFunName);
-        rel_6_new_LiveFunName->purge();
-        iter++;
-      }
-      iter = 0;
-      if (!isHintsProfilingEnabled())
-        rel_5_delta_LiveFunName->purge();
-      if (!isHintsProfilingEnabled())
-        rel_6_new_LiveFunName->purge();
-      if (performIO) {
-        try {
-          std::map<std::string, std::string> directiveMap(
-              {{"IO", "file"},
-               {"attributeNames", "fun"},
-               {"filename", "./LiveFunName.csv"},
-               {"name", "LiveFunName"}});
-          if (!outputDirectory.empty() && directiveMap["IO"] == "file" &&
-              directiveMap["filename"].front() != '/') {
-            directiveMap["filename"] =
-                outputDirectory + "/" + directiveMap["filename"];
-          }
-          IODirectives ioDirectives(directiveMap);
-          IOSystem::getInstance()
-              .getWriter(std::vector<bool>({1}), symTable, ioDirectives, false,
-                         1)
-              ->writeAll(*rel_4_LiveFunName);
-        } catch (std::exception &e) {
-          std::cerr << e.what();
-          exit(1);
-        }
-      }
-      if (!isHintsProfilingEnabled() && performIO)
-        rel_2_FunReference->purge();
-    }();
-    /* END STRATUM 3 */
-    /* BEGIN STRATUM 4 */
-    [&]() {
-      if (performIO) {
-        try {
-          std::map<std::string, std::string> directiveMap(
-              {{"IO", "file"},
-               {"filename", "./TyCon.facts"},
-               {"name", "TyCon"}});
-          if (!inputDirectory.empty() && directiveMap["IO"] == "file" &&
-              directiveMap["filename"].front() != '/') {
-            directiveMap["filename"] =
-                inputDirectory + "/" + directiveMap["filename"];
-          }
-          IODirectives ioDirectives(directiveMap);
-          IOSystem::getInstance()
-              .getReader(std::vector<bool>({1, 1}), symTable, ioDirectives,
-                         false, 1)
-              ->readAll(*rel_7_TyCon);
-        } catch (std::exception &e) {
-          std::cerr << "Error loading data: " << e.what() << '\n';
-        }
-      }
-    }();
-    /* END STRATUM 4 */
-    /* BEGIN STRATUM 5 */
-    [&]() {
-      SignalHandler::instance()->setMsg(R"_(LiveDataConName(fun) :- 
+in file /Users/luc/personal/souffle-hs/ext-stg-liveness.dl [33:1-35:26])_");
+if(!(rel_1_delta_LiveFunName->empty()) && !(rel_4_FunReference->empty())) {
+[&](){
+CREATE_OP_CONTEXT(rel_4_FunReference_op_ctxt,rel_4_FunReference->createContext());
+CREATE_OP_CONTEXT(rel_6_LiveFunName_op_ctxt,rel_6_LiveFunName->createContext());
+CREATE_OP_CONTEXT(rel_1_delta_LiveFunName_op_ctxt,rel_1_delta_LiveFunName->createContext());
+CREATE_OP_CONTEXT(rel_2_new_LiveFunName_op_ctxt,rel_2_new_LiveFunName->createContext());
+for(const auto& env0 : *rel_1_delta_LiveFunName) {
+const Tuple<RamDomain,2> lower{{ramBitCast(env0[0]),0}};
+const Tuple<RamDomain,2> upper{{ramBitCast(env0[0]),0}};
+auto range = rel_4_FunReference->lowerUpperRange_01(lower, upper,READ_OP_CONTEXT(rel_4_FunReference_op_ctxt));
+for(const auto& env1 : range) {
+if( !(rel_6_LiveFunName->contains(Tuple<RamDomain,1>{{ramBitCast(env1[1])}},READ_OP_CONTEXT(rel_6_LiveFunName_op_ctxt)))) {
+Tuple<RamDomain,1> tuple{{ramBitCast(env1[1])}};
+rel_2_new_LiveFunName->insert(tuple,READ_OP_CONTEXT(rel_2_new_LiveFunName_op_ctxt));
+}
+}
+}
+}
+();}
+if(rel_2_new_LiveFunName->empty()) break;
+[&](){
+CREATE_OP_CONTEXT(rel_6_LiveFunName_op_ctxt,rel_6_LiveFunName->createContext());
+CREATE_OP_CONTEXT(rel_2_new_LiveFunName_op_ctxt,rel_2_new_LiveFunName->createContext());
+for(const auto& env0 : *rel_2_new_LiveFunName) {
+Tuple<RamDomain,1> tuple{{ramBitCast(env0[0])}};
+rel_6_LiveFunName->insert(tuple,READ_OP_CONTEXT(rel_6_LiveFunName_op_ctxt));
+}
+}
+();std::swap(rel_1_delta_LiveFunName, rel_2_new_LiveFunName);
+rel_2_new_LiveFunName->purge();
+iter++;
+}
+iter = 0;
+rel_1_delta_LiveFunName->purge();
+rel_2_new_LiveFunName->purge();
+if (performIO) {
+try {std::map<std::string, std::string> directiveMap({{"IO","file"},{"attributeNames","fun"},{"filename","./LiveFunName.csv"},{"name","LiveFunName"},{"operation","output"},{"types","{\"LiveFunName\": {\"arity\": 1, \"auxArity\": 0, \"types\": [\"s:Name\"]}, \"records\": {}}"}});
+if (!outputDirectory.empty() && directiveMap["filename"].front() != '/') {directiveMap["filename"] = outputDirectory + "/" + directiveMap["filename"];}
+IOSystem::getInstance().getWriter(directiveMap, symTable, recordTable)->writeAll(*rel_6_LiveFunName);
+} catch (std::exception& e) {std::cerr << e.what();exit(1);}
+}
+if (performIO) rel_4_FunReference->purge();
+}
+void subroutine_6(const std::vector<RamDomain>& args, std::vector<RamDomain>& ret) {
+SignalHandler::instance()->setMsg(R"_(LiveDataConName(fun) :- 
    LiveSource(fun).
-in file /home/csaba/haskell/grin-compiler/ghc-whole-program-compiler-project/external-stg-compiler/datalog/ext-stg-liveness.dl [38:1-39:19])_");
-      if (!(rel_3_LiveSource->empty())) {
-        [&]() {
-          CREATE_OP_CONTEXT(rel_8_LiveDataConName_op_ctxt,
-                            rel_8_LiveDataConName->createContext());
-          CREATE_OP_CONTEXT(rel_3_LiveSource_op_ctxt,
-                            rel_3_LiveSource->createContext());
-          for (const auto &env0 : *rel_3_LiveSource) {
-            Tuple<RamDomain, 1> tuple{{static_cast<RamDomain>(env0[0])}};
-            rel_8_LiveDataConName->insert(
-                tuple, READ_OP_CONTEXT(rel_8_LiveDataConName_op_ctxt));
-          }
-        }();
-      }
-      SignalHandler::instance()->setMsg(R"_(LiveDataConName(datacon) :- 
+in file /Users/luc/personal/souffle-hs/ext-stg-liveness.dl [38:1-39:19])_");
+if(!(rel_7_LiveSource->empty())) {
+[&](){
+CREATE_OP_CONTEXT(rel_7_LiveSource_op_ctxt,rel_7_LiveSource->createContext());
+CREATE_OP_CONTEXT(rel_5_LiveDataConName_op_ctxt,rel_5_LiveDataConName->createContext());
+for(const auto& env0 : *rel_7_LiveSource) {
+Tuple<RamDomain,1> tuple{{ramBitCast(env0[0])}};
+rel_5_LiveDataConName->insert(tuple,READ_OP_CONTEXT(rel_5_LiveDataConName_op_ctxt));
+}
+}
+();}
+SignalHandler::instance()->setMsg(R"_(LiveDataConName(datacon) :- 
    LiveFunName(fun),
    DataConReference(fun,datacon).
-in file /home/csaba/haskell/grin-compiler/ghc-whole-program-compiler-project/external-stg-compiler/datalog/ext-stg-liveness.dl [41:1-43:34])_");
-      if (!(rel_1_DataConReference->empty()) && !(rel_4_LiveFunName->empty())) {
-        [&]() {
-          CREATE_OP_CONTEXT(rel_8_LiveDataConName_op_ctxt,
-                            rel_8_LiveDataConName->createContext());
-          CREATE_OP_CONTEXT(rel_4_LiveFunName_op_ctxt,
-                            rel_4_LiveFunName->createContext());
-          CREATE_OP_CONTEXT(rel_1_DataConReference_op_ctxt,
-                            rel_1_DataConReference->createContext());
-          for (const auto &env0 : *rel_4_LiveFunName) {
-            const Tuple<RamDomain, 2> key{{env0[0], 0}};
-            auto range = rel_1_DataConReference->equalRange_1(
-                key, READ_OP_CONTEXT(rel_1_DataConReference_op_ctxt));
-            for (const auto &env1 : range) {
-              Tuple<RamDomain, 1> tuple{{static_cast<RamDomain>(env1[1])}};
-              rel_8_LiveDataConName->insert(
-                  tuple, READ_OP_CONTEXT(rel_8_LiveDataConName_op_ctxt));
-            }
-          }
-        }();
-      }
-      SignalHandler::instance()->setMsg(R"_(LiveDataConName(datacon) :- 
+in file /Users/luc/personal/souffle-hs/ext-stg-liveness.dl [41:1-43:34])_");
+if(!(rel_6_LiveFunName->empty()) && !(rel_3_DataConReference->empty())) {
+[&](){
+CREATE_OP_CONTEXT(rel_3_DataConReference_op_ctxt,rel_3_DataConReference->createContext());
+CREATE_OP_CONTEXT(rel_6_LiveFunName_op_ctxt,rel_6_LiveFunName->createContext());
+CREATE_OP_CONTEXT(rel_5_LiveDataConName_op_ctxt,rel_5_LiveDataConName->createContext());
+for(const auto& env0 : *rel_6_LiveFunName) {
+const Tuple<RamDomain,2> lower{{ramBitCast(env0[0]),0}};
+const Tuple<RamDomain,2> upper{{ramBitCast(env0[0]),0}};
+auto range = rel_3_DataConReference->lowerUpperRange_01(lower, upper,READ_OP_CONTEXT(rel_3_DataConReference_op_ctxt));
+for(const auto& env1 : range) {
+Tuple<RamDomain,1> tuple{{ramBitCast(env1[1])}};
+rel_5_LiveDataConName->insert(tuple,READ_OP_CONTEXT(rel_5_LiveDataConName_op_ctxt));
+}
+}
+}
+();}
+SignalHandler::instance()->setMsg(R"_(LiveDataConName(datacon) :- 
    TyCon(_,datacon).
-in file /home/csaba/haskell/grin-compiler/ghc-whole-program-compiler-project/external-stg-compiler/datalog/ext-stg-liveness.dl [57:1-58:21])_");
-      if (!(rel_7_TyCon->empty())) {
-        [&]() {
-          CREATE_OP_CONTEXT(rel_8_LiveDataConName_op_ctxt,
-                            rel_8_LiveDataConName->createContext());
-          CREATE_OP_CONTEXT(rel_7_TyCon_op_ctxt, rel_7_TyCon->createContext());
-          for (const auto &env0 : *rel_7_TyCon) {
-            Tuple<RamDomain, 1> tuple{{static_cast<RamDomain>(env0[1])}};
-            rel_8_LiveDataConName->insert(
-                tuple, READ_OP_CONTEXT(rel_8_LiveDataConName_op_ctxt));
-          }
-        }();
-      }
-      if (performIO) {
-        try {
-          std::map<std::string, std::string> directiveMap(
-              {{"IO", "file"},
-               {"attributeNames", "datacon"},
-               {"filename", "./LiveDataConName.csv"},
-               {"name", "LiveDataConName"}});
-          if (!outputDirectory.empty() && directiveMap["IO"] == "file" &&
-              directiveMap["filename"].front() != '/') {
-            directiveMap["filename"] =
-                outputDirectory + "/" + directiveMap["filename"];
-          }
-          IODirectives ioDirectives(directiveMap);
-          IOSystem::getInstance()
-              .getWriter(std::vector<bool>({1}), symTable, ioDirectives, false,
-                         1)
-              ->writeAll(*rel_8_LiveDataConName);
-        } catch (std::exception &e) {
-          std::cerr << e.what();
-          exit(1);
-        }
-      }
-      if (!isHintsProfilingEnabled() && performIO)
-        rel_1_DataConReference->purge();
-      if (!isHintsProfilingEnabled() && performIO)
-        rel_3_LiveSource->purge();
-    }();
-    /* END STRATUM 5 */
-    /* BEGIN STRATUM 6 */
-    [&]() {
-      if (performIO) {
-        try {
-          std::map<std::string, std::string> directiveMap(
-              {{"IO", "file"},
-               {"filename", "./TyConReference.facts"},
-               {"name", "TyConReference"}});
-          if (!inputDirectory.empty() && directiveMap["IO"] == "file" &&
-              directiveMap["filename"].front() != '/') {
-            directiveMap["filename"] =
-                inputDirectory + "/" + directiveMap["filename"];
-          }
-          IODirectives ioDirectives(directiveMap);
-          IOSystem::getInstance()
-              .getReader(std::vector<bool>({1, 1}), symTable, ioDirectives,
-                         false, 1)
-              ->readAll(*rel_9_TyConReference);
-        } catch (std::exception &e) {
-          std::cerr << "Error loading data: " << e.what() << '\n';
-        }
-      }
-    }();
-    /* END STRATUM 6 */
-    /* BEGIN STRATUM 7 */
-    [&]() {
-      SignalHandler::instance()->setMsg(R"_(LiveTyConName(tycon) :- 
+in file /Users/luc/personal/souffle-hs/ext-stg-liveness.dl [57:1-58:21])_");
+if(!(rel_9_TyCon->empty())) {
+[&](){
+CREATE_OP_CONTEXT(rel_9_TyCon_op_ctxt,rel_9_TyCon->createContext());
+CREATE_OP_CONTEXT(rel_5_LiveDataConName_op_ctxt,rel_5_LiveDataConName->createContext());
+for(const auto& env0 : *rel_9_TyCon) {
+Tuple<RamDomain,1> tuple{{ramBitCast(env0[1])}};
+rel_5_LiveDataConName->insert(tuple,READ_OP_CONTEXT(rel_5_LiveDataConName_op_ctxt));
+}
+}
+();}
+if (performIO) {
+try {std::map<std::string, std::string> directiveMap({{"IO","file"},{"attributeNames","datacon"},{"filename","./LiveDataConName.csv"},{"name","LiveDataConName"},{"operation","output"},{"types","{\"LiveDataConName\": {\"arity\": 1, \"auxArity\": 0, \"types\": [\"s:Name\"]}, \"records\": {}}"}});
+if (!outputDirectory.empty() && directiveMap["filename"].front() != '/') {directiveMap["filename"] = outputDirectory + "/" + directiveMap["filename"];}
+IOSystem::getInstance().getWriter(directiveMap, symTable, recordTable)->writeAll(*rel_5_LiveDataConName);
+} catch (std::exception& e) {std::cerr << e.what();exit(1);}
+}
+if (performIO) rel_3_DataConReference->purge();
+if (performIO) rel_7_LiveSource->purge();
+}
+void subroutine_7(const std::vector<RamDomain>& args, std::vector<RamDomain>& ret) {
+SignalHandler::instance()->setMsg(R"_(LiveTyConName(tycon) :- 
    LiveDataConName(datacon),
    TyCon(tycon,datacon).
-in file /home/csaba/haskell/grin-compiler/ghc-whole-program-compiler-project/external-stg-compiler/datalog/ext-stg-liveness.dl [46:1-48:25])_");
-      if (!(rel_7_TyCon->empty()) && !(rel_8_LiveDataConName->empty())) {
-        [&]() {
-          CREATE_OP_CONTEXT(rel_8_LiveDataConName_op_ctxt,
-                            rel_8_LiveDataConName->createContext());
-          CREATE_OP_CONTEXT(rel_7_TyCon_op_ctxt, rel_7_TyCon->createContext());
-          CREATE_OP_CONTEXT(rel_10_LiveTyConName_op_ctxt,
-                            rel_10_LiveTyConName->createContext());
-          for (const auto &env0 : *rel_8_LiveDataConName) {
-            const Tuple<RamDomain, 2> key{{0, env0[0]}};
-            auto range = rel_7_TyCon->equalRange_2(
-                key, READ_OP_CONTEXT(rel_7_TyCon_op_ctxt));
-            for (const auto &env1 : range) {
-              Tuple<RamDomain, 1> tuple{{static_cast<RamDomain>(env1[0])}};
-              rel_10_LiveTyConName->insert(
-                  tuple, READ_OP_CONTEXT(rel_10_LiveTyConName_op_ctxt));
-            }
-          }
-        }();
-      }
-      SignalHandler::instance()->setMsg(R"_(LiveTyConName(tycon) :- 
+in file /Users/luc/personal/souffle-hs/ext-stg-liveness.dl [46:1-48:25])_");
+if(!(rel_5_LiveDataConName->empty()) && !(rel_9_TyCon->empty())) {
+[&](){
+CREATE_OP_CONTEXT(rel_9_TyCon_op_ctxt,rel_9_TyCon->createContext());
+CREATE_OP_CONTEXT(rel_5_LiveDataConName_op_ctxt,rel_5_LiveDataConName->createContext());
+CREATE_OP_CONTEXT(rel_8_LiveTyConName_op_ctxt,rel_8_LiveTyConName->createContext());
+for(const auto& env0 : *rel_5_LiveDataConName) {
+const Tuple<RamDomain,2> lower{{0,ramBitCast(env0[0])}};
+const Tuple<RamDomain,2> upper{{0,ramBitCast(env0[0])}};
+auto range = rel_9_TyCon->lowerUpperRange_10(lower, upper,READ_OP_CONTEXT(rel_9_TyCon_op_ctxt));
+for(const auto& env1 : range) {
+Tuple<RamDomain,1> tuple{{ramBitCast(env1[0])}};
+rel_8_LiveTyConName->insert(tuple,READ_OP_CONTEXT(rel_8_LiveTyConName_op_ctxt));
+}
+}
+}
+();}
+SignalHandler::instance()->setMsg(R"_(LiveTyConName(tycon) :- 
    LiveFunName(fun),
    TyConReference(fun,tycon).
-in file /home/csaba/haskell/grin-compiler/ghc-whole-program-compiler-project/external-stg-compiler/datalog/ext-stg-liveness.dl [50:1-52:30])_");
-      if (!(rel_9_TyConReference->empty()) && !(rel_4_LiveFunName->empty())) {
-        [&]() {
-          CREATE_OP_CONTEXT(rel_4_LiveFunName_op_ctxt,
-                            rel_4_LiveFunName->createContext());
-          CREATE_OP_CONTEXT(rel_10_LiveTyConName_op_ctxt,
-                            rel_10_LiveTyConName->createContext());
-          CREATE_OP_CONTEXT(rel_9_TyConReference_op_ctxt,
-                            rel_9_TyConReference->createContext());
-          for (const auto &env0 : *rel_4_LiveFunName) {
-            const Tuple<RamDomain, 2> key{{env0[0], 0}};
-            auto range = rel_9_TyConReference->equalRange_1(
-                key, READ_OP_CONTEXT(rel_9_TyConReference_op_ctxt));
-            for (const auto &env1 : range) {
-              Tuple<RamDomain, 1> tuple{{static_cast<RamDomain>(env1[1])}};
-              rel_10_LiveTyConName->insert(
-                  tuple, READ_OP_CONTEXT(rel_10_LiveTyConName_op_ctxt));
-            }
-          }
-        }();
-      }
-      if (performIO) {
-        try {
-          std::map<std::string, std::string> directiveMap(
-              {{"IO", "file"},
-               {"attributeNames", "tycon"},
-               {"filename", "./LiveTyConName.csv"},
-               {"name", "LiveTyConName"}});
-          if (!outputDirectory.empty() && directiveMap["IO"] == "file" &&
-              directiveMap["filename"].front() != '/') {
-            directiveMap["filename"] =
-                outputDirectory + "/" + directiveMap["filename"];
-          }
-          IODirectives ioDirectives(directiveMap);
-          IOSystem::getInstance()
-              .getWriter(std::vector<bool>({1}), symTable, ioDirectives, false,
-                         1)
-              ->writeAll(*rel_10_LiveTyConName);
-        } catch (std::exception &e) {
-          std::cerr << e.what();
-          exit(1);
-        }
-      }
-      if (!isHintsProfilingEnabled() && performIO)
-        rel_7_TyCon->purge();
-      if (!isHintsProfilingEnabled() && performIO)
-        rel_9_TyConReference->purge();
-      if (!isHintsProfilingEnabled() && performIO)
-        rel_4_LiveFunName->purge();
-      if (!isHintsProfilingEnabled() && performIO)
-        rel_8_LiveDataConName->purge();
-    }();
-    /* END STRATUM 7 */
-
-    // -- relation hint statistics --
-    if (isHintsProfilingEnabled()) {
-      std::cout << " -- Operation Hint Statistics --\n";
-      std::cout << "Relation rel_1_DataConReference:\n";
-      rel_1_DataConReference->printHintStatistics(std::cout, "  ");
-      std::cout << "\n";
-      std::cout << "Relation rel_2_FunReference:\n";
-      rel_2_FunReference->printHintStatistics(std::cout, "  ");
-      std::cout << "\n";
-      std::cout << "Relation rel_3_LiveSource:\n";
-      rel_3_LiveSource->printHintStatistics(std::cout, "  ");
-      std::cout << "\n";
-      std::cout << "Relation rel_4_LiveFunName:\n";
-      rel_4_LiveFunName->printHintStatistics(std::cout, "  ");
-      std::cout << "\n";
-      std::cout << "Relation rel_5_delta_LiveFunName:\n";
-      rel_5_delta_LiveFunName->printHintStatistics(std::cout, "  ");
-      std::cout << "\n";
-      std::cout << "Relation rel_6_new_LiveFunName:\n";
-      rel_6_new_LiveFunName->printHintStatistics(std::cout, "  ");
-      std::cout << "\n";
-      std::cout << "Relation rel_7_TyCon:\n";
-      rel_7_TyCon->printHintStatistics(std::cout, "  ");
-      std::cout << "\n";
-      std::cout << "Relation rel_8_LiveDataConName:\n";
-      rel_8_LiveDataConName->printHintStatistics(std::cout, "  ");
-      std::cout << "\n";
-      std::cout << "Relation rel_9_TyConReference:\n";
-      rel_9_TyConReference->printHintStatistics(std::cout, "  ");
-      std::cout << "\n";
-      std::cout << "Relation rel_10_LiveTyConName:\n";
-      rel_10_LiveTyConName->printHintStatistics(std::cout, "  ");
-      std::cout << "\n";
-    }
-    SignalHandler::instance()->reset();
-  }
-
-public:
-  void run(size_t stratumIndex = (size_t)-1) override {
-    runFunction(".", ".", stratumIndex, false);
-  }
-
-public:
-  void runAll(std::string inputDirectory = ".",
-              std::string outputDirectory = ".",
-              size_t stratumIndex = (size_t)-1) override {
-    runFunction(inputDirectory, outputDirectory, stratumIndex, true);
-  }
-
-public:
-  void printAll(std::string outputDirectory = ".") override {
-    try {
-      std::map<std::string, std::string> directiveMap(
-          {{"IO", "file"},
-           {"attributeNames", "fun"},
-           {"filename", "./LiveFunName.csv"},
-           {"name", "LiveFunName"}});
-      if (!outputDirectory.empty() && directiveMap["IO"] == "file" &&
-          directiveMap["filename"].front() != '/') {
-        directiveMap["filename"] =
-            outputDirectory + "/" + directiveMap["filename"];
-      }
-      IODirectives ioDirectives(directiveMap);
-      IOSystem::getInstance()
-          .getWriter(std::vector<bool>({1}), symTable, ioDirectives, false, 1)
-          ->writeAll(*rel_4_LiveFunName);
-    } catch (std::exception &e) {
-      std::cerr << e.what();
-      exit(1);
-    }
-    try {
-      std::map<std::string, std::string> directiveMap(
-          {{"IO", "file"},
-           {"attributeNames", "datacon"},
-           {"filename", "./LiveDataConName.csv"},
-           {"name", "LiveDataConName"}});
-      if (!outputDirectory.empty() && directiveMap["IO"] == "file" &&
-          directiveMap["filename"].front() != '/') {
-        directiveMap["filename"] =
-            outputDirectory + "/" + directiveMap["filename"];
-      }
-      IODirectives ioDirectives(directiveMap);
-      IOSystem::getInstance()
-          .getWriter(std::vector<bool>({1}), symTable, ioDirectives, false, 1)
-          ->writeAll(*rel_8_LiveDataConName);
-    } catch (std::exception &e) {
-      std::cerr << e.what();
-      exit(1);
-    }
-    try {
-      std::map<std::string, std::string> directiveMap(
-          {{"IO", "file"},
-           {"attributeNames", "tycon"},
-           {"filename", "./LiveTyConName.csv"},
-           {"name", "LiveTyConName"}});
-      if (!outputDirectory.empty() && directiveMap["IO"] == "file" &&
-          directiveMap["filename"].front() != '/') {
-        directiveMap["filename"] =
-            outputDirectory + "/" + directiveMap["filename"];
-      }
-      IODirectives ioDirectives(directiveMap);
-      IOSystem::getInstance()
-          .getWriter(std::vector<bool>({1}), symTable, ioDirectives, false, 1)
-          ->writeAll(*rel_10_LiveTyConName);
-    } catch (std::exception &e) {
-      std::cerr << e.what();
-      exit(1);
-    }
-  }
-
-public:
-  void loadAll(std::string inputDirectory = ".") override {
-    try {
-      std::map<std::string, std::string> directiveMap(
-          {{"IO", "file"},
-           {"filename", "./DataConReference.facts"},
-           {"name", "DataConReference"}});
-      if (!inputDirectory.empty() && directiveMap["IO"] == "file" &&
-          directiveMap["filename"].front() != '/') {
-        directiveMap["filename"] =
-            inputDirectory + "/" + directiveMap["filename"];
-      }
-      IODirectives ioDirectives(directiveMap);
-      IOSystem::getInstance()
-          .getReader(std::vector<bool>({1, 1}), symTable, ioDirectives, false,
-                     1)
-          ->readAll(*rel_1_DataConReference);
-    } catch (std::exception &e) {
-      std::cerr << "Error loading data: " << e.what() << '\n';
-    }
-    try {
-      std::map<std::string, std::string> directiveMap(
-          {{"IO", "file"},
-           {"filename", "./FunReference.facts"},
-           {"name", "FunReference"}});
-      if (!inputDirectory.empty() && directiveMap["IO"] == "file" &&
-          directiveMap["filename"].front() != '/') {
-        directiveMap["filename"] =
-            inputDirectory + "/" + directiveMap["filename"];
-      }
-      IODirectives ioDirectives(directiveMap);
-      IOSystem::getInstance()
-          .getReader(std::vector<bool>({1, 1}), symTable, ioDirectives, false,
-                     1)
-          ->readAll(*rel_2_FunReference);
-    } catch (std::exception &e) {
-      std::cerr << "Error loading data: " << e.what() << '\n';
-    }
-    try {
-      std::map<std::string, std::string> directiveMap(
-          {{"IO", "file"},
-           {"filename", "./LiveSource.facts"},
-           {"name", "LiveSource"}});
-      if (!inputDirectory.empty() && directiveMap["IO"] == "file" &&
-          directiveMap["filename"].front() != '/') {
-        directiveMap["filename"] =
-            inputDirectory + "/" + directiveMap["filename"];
-      }
-      IODirectives ioDirectives(directiveMap);
-      IOSystem::getInstance()
-          .getReader(std::vector<bool>({1}), symTable, ioDirectives, false, 1)
-          ->readAll(*rel_3_LiveSource);
-    } catch (std::exception &e) {
-      std::cerr << "Error loading data: " << e.what() << '\n';
-    }
-    try {
-      std::map<std::string, std::string> directiveMap(
-          {{"IO", "file"}, {"filename", "./TyCon.facts"}, {"name", "TyCon"}});
-      if (!inputDirectory.empty() && directiveMap["IO"] == "file" &&
-          directiveMap["filename"].front() != '/') {
-        directiveMap["filename"] =
-            inputDirectory + "/" + directiveMap["filename"];
-      }
-      IODirectives ioDirectives(directiveMap);
-      IOSystem::getInstance()
-          .getReader(std::vector<bool>({1, 1}), symTable, ioDirectives, false,
-                     1)
-          ->readAll(*rel_7_TyCon);
-    } catch (std::exception &e) {
-      std::cerr << "Error loading data: " << e.what() << '\n';
-    }
-    try {
-      std::map<std::string, std::string> directiveMap(
-          {{"IO", "file"},
-           {"filename", "./TyConReference.facts"},
-           {"name", "TyConReference"}});
-      if (!inputDirectory.empty() && directiveMap["IO"] == "file" &&
-          directiveMap["filename"].front() != '/') {
-        directiveMap["filename"] =
-            inputDirectory + "/" + directiveMap["filename"];
-      }
-      IODirectives ioDirectives(directiveMap);
-      IOSystem::getInstance()
-          .getReader(std::vector<bool>({1, 1}), symTable, ioDirectives, false,
-                     1)
-          ->readAll(*rel_9_TyConReference);
-    } catch (std::exception &e) {
-      std::cerr << "Error loading data: " << e.what() << '\n';
-    }
-  }
-
-public:
-  void dumpInputs(std::ostream &out = std::cout) override {
-    try {
-      IODirectives ioDirectives;
-      ioDirectives.setIOType("stdout");
-      ioDirectives.setRelationName("rel_1_DataConReference");
-      IOSystem::getInstance()
-          .getWriter(std::vector<bool>({1, 1}), symTable, ioDirectives, false,
-                     1)
-          ->writeAll(*rel_1_DataConReference);
-    } catch (std::exception &e) {
-      std::cerr << e.what();
-      exit(1);
-    }
-    try {
-      IODirectives ioDirectives;
-      ioDirectives.setIOType("stdout");
-      ioDirectives.setRelationName("rel_2_FunReference");
-      IOSystem::getInstance()
-          .getWriter(std::vector<bool>({1, 1}), symTable, ioDirectives, false,
-                     1)
-          ->writeAll(*rel_2_FunReference);
-    } catch (std::exception &e) {
-      std::cerr << e.what();
-      exit(1);
-    }
-    try {
-      IODirectives ioDirectives;
-      ioDirectives.setIOType("stdout");
-      ioDirectives.setRelationName("rel_3_LiveSource");
-      IOSystem::getInstance()
-          .getWriter(std::vector<bool>({1}), symTable, ioDirectives, false, 1)
-          ->writeAll(*rel_3_LiveSource);
-    } catch (std::exception &e) {
-      std::cerr << e.what();
-      exit(1);
-    }
-    try {
-      IODirectives ioDirectives;
-      ioDirectives.setIOType("stdout");
-      ioDirectives.setRelationName("rel_7_TyCon");
-      IOSystem::getInstance()
-          .getWriter(std::vector<bool>({1, 1}), symTable, ioDirectives, false,
-                     1)
-          ->writeAll(*rel_7_TyCon);
-    } catch (std::exception &e) {
-      std::cerr << e.what();
-      exit(1);
-    }
-    try {
-      IODirectives ioDirectives;
-      ioDirectives.setIOType("stdout");
-      ioDirectives.setRelationName("rel_9_TyConReference");
-      IOSystem::getInstance()
-          .getWriter(std::vector<bool>({1, 1}), symTable, ioDirectives, false,
-                     1)
-          ->writeAll(*rel_9_TyConReference);
-    } catch (std::exception &e) {
-      std::cerr << e.what();
-      exit(1);
-    }
-  }
-
-public:
-  void dumpOutputs(std::ostream &out = std::cout) override {
-    try {
-      IODirectives ioDirectives;
-      ioDirectives.setIOType("stdout");
-      ioDirectives.setRelationName("rel_4_LiveFunName");
-      IOSystem::getInstance()
-          .getWriter(std::vector<bool>({1}), symTable, ioDirectives, false, 1)
-          ->writeAll(*rel_4_LiveFunName);
-    } catch (std::exception &e) {
-      std::cerr << e.what();
-      exit(1);
-    }
-    try {
-      IODirectives ioDirectives;
-      ioDirectives.setIOType("stdout");
-      ioDirectives.setRelationName("rel_8_LiveDataConName");
-      IOSystem::getInstance()
-          .getWriter(std::vector<bool>({1}), symTable, ioDirectives, false, 1)
-          ->writeAll(*rel_8_LiveDataConName);
-    } catch (std::exception &e) {
-      std::cerr << e.what();
-      exit(1);
-    }
-    try {
-      IODirectives ioDirectives;
-      ioDirectives.setIOType("stdout");
-      ioDirectives.setRelationName("rel_10_LiveTyConName");
-      IOSystem::getInstance()
-          .getWriter(std::vector<bool>({1}), symTable, ioDirectives, false, 1)
-          ->writeAll(*rel_10_LiveTyConName);
-    } catch (std::exception &e) {
-      std::cerr << e.what();
-      exit(1);
-    }
-  }
-
-public:
-  SymbolTable &getSymbolTable() override { return symTable; }
+in file /Users/luc/personal/souffle-hs/ext-stg-liveness.dl [50:1-52:30])_");
+if(!(rel_6_LiveFunName->empty()) && !(rel_10_TyConReference->empty())) {
+[&](){
+CREATE_OP_CONTEXT(rel_10_TyConReference_op_ctxt,rel_10_TyConReference->createContext());
+CREATE_OP_CONTEXT(rel_6_LiveFunName_op_ctxt,rel_6_LiveFunName->createContext());
+CREATE_OP_CONTEXT(rel_8_LiveTyConName_op_ctxt,rel_8_LiveTyConName->createContext());
+for(const auto& env0 : *rel_6_LiveFunName) {
+const Tuple<RamDomain,2> lower{{ramBitCast(env0[0]),0}};
+const Tuple<RamDomain,2> upper{{ramBitCast(env0[0]),0}};
+auto range = rel_10_TyConReference->lowerUpperRange_01(lower, upper,READ_OP_CONTEXT(rel_10_TyConReference_op_ctxt));
+for(const auto& env1 : range) {
+Tuple<RamDomain,1> tuple{{ramBitCast(env1[1])}};
+rel_8_LiveTyConName->insert(tuple,READ_OP_CONTEXT(rel_8_LiveTyConName_op_ctxt));
+}
+}
+}
+();}
+if (performIO) {
+try {std::map<std::string, std::string> directiveMap({{"IO","file"},{"attributeNames","tycon"},{"filename","./LiveTyConName.csv"},{"name","LiveTyConName"},{"operation","output"},{"types","{\"LiveTyConName\": {\"arity\": 1, \"auxArity\": 0, \"types\": [\"s:Name\"]}, \"records\": {}}"}});
+if (!outputDirectory.empty() && directiveMap["filename"].front() != '/') {directiveMap["filename"] = outputDirectory + "/" + directiveMap["filename"];}
+IOSystem::getInstance().getWriter(directiveMap, symTable, recordTable)->writeAll(*rel_8_LiveTyConName);
+} catch (std::exception& e) {std::cerr << e.what();exit(1);}
+}
+if (performIO) rel_9_TyCon->purge();
+if (performIO) rel_10_TyConReference->purge();
+if (performIO) rel_6_LiveFunName->purge();
+if (performIO) rel_5_LiveDataConName->purge();
+}
 };
-SouffleProgram *newInstance_ext_stg_liveness() {
-  return new Sf_ext_stg_liveness;
-}
-SymbolTable *getST_ext_stg_liveness(SouffleProgram *p) {
-  return &reinterpret_cast<Sf_ext_stg_liveness *>(p)->symTable;
-}
+SouffleProgram *newInstance_ext_stg_liveness(){return new Sf_ext_stg_liveness;}
+SymbolTable *getST_ext_stg_liveness(SouffleProgram *p){return &reinterpret_cast<Sf_ext_stg_liveness*>(p)->symTable;}
 
 #ifdef __EMBEDDED_SOUFFLE__
-class factory_Sf_ext_stg_liveness : public souffle::ProgramFactory {
-  SouffleProgram *newInstance() { return new Sf_ext_stg_liveness(); };
-
-public:
-  factory_Sf_ext_stg_liveness() : ProgramFactory("ext_stg_liveness") {}
+class factory_Sf_ext_stg_liveness: public souffle::ProgramFactory {
+SouffleProgram *newInstance() {
+return new Sf_ext_stg_liveness();
 };
-static factory_Sf_ext_stg_liveness __factory_Sf_ext_stg_liveness_instance;
+public:
+factory_Sf_ext_stg_liveness() : ProgramFactory("ext_stg_liveness"){}
+};
+extern "C" {
+factory_Sf_ext_stg_liveness __factory_Sf_ext_stg_liveness_instance;
+}
 }
 #else
 }
-int main(int argc, char **argv) {
-  try {
-    souffle::CmdOptions opt(R"(ext-stg-liveness.dl)", R"(.)", R"(.)", false,
-                            R"()", 4, -1);
-    if (!opt.parse(argc, argv))
-      return 1;
-    souffle::Sf_ext_stg_liveness obj;
-#if defined(_OPENMP)
-    obj.setNumThreads(opt.getNumJobs());
+int main(int argc, char** argv)
+{
+try{
+souffle::CmdOptions opt(R"(ext-stg-liveness.dl)",
+R"(.)",
+R"(.)",
+false,
+R"()",
+1);
+if (!opt.parse(argc,argv)) return 1;
+souffle::Sf_ext_stg_liveness obj;
+#if defined(_OPENMP) 
+obj.setNumThreads(opt.getNumJobs());
 
 #endif
-    obj.runAll(opt.getInputFileDir(), opt.getOutputFileDir(),
-               opt.getStratumIndex());
-    return 0;
-  } catch (std::exception &e) {
-    souffle::SignalHandler::instance()->error(e.what());
-  }
+obj.runAll(opt.getInputFileDir(), opt.getOutputFileDir());
+return 0;
+} catch(std::exception &e) { souffle::SignalHandler::instance()->error(e.what());}
 }
 
 #endif

--- a/external-stg-compiler/external-stg-compiler.cabal
+++ b/external-stg-compiler/external-stg-compiler.cabal
@@ -47,12 +47,8 @@ library
 
   extra-libraries:      gomp
 
--- HINT: temporarly disabled, it is embedded using Template Haskell
---  cxx-sources:          cbits/ext-stg-liveness.cpp
+  cxx-sources:          cbits/ext-stg-liveness.cpp
   cxx-options:          -D__EMBEDDED_SOUFFLE__ -D_OPENMP -std=c++17
-
-  -- dirty workaround for Template Haskell embedded C++ sources
-  cpp-options:          -D__EMBEDDED_SOUFFLE__ -D_OPENMP -std=c++17
 
 executable gen-exe
   hs-source-dirs:      app

--- a/external-stg-compiler/lib/Stg/DeadFunctionElimination/Analysis.hs
+++ b/external-stg-compiler/lib/Stg/DeadFunctionElimination/Analysis.hs
@@ -5,7 +5,6 @@ module Stg.DeadFunctionElimination.Analysis where
 import Control.Monad.IO.Class
 import qualified Language.Souffle.Class     as Souffle
 import qualified Language.Souffle.Compiled  as Souffle
-import qualified Language.Souffle.TH        as Souffle
 
 import Control.Monad
 import Data.Word
@@ -21,7 +20,6 @@ import System.IO.Temp
 
 import qualified Stg.GHC.Symbols as GHCSymbols
 
-Souffle.embedProgram "cbits/ext-stg-liveness.cpp"
 {-
   TODO:
     done - collect module facts

--- a/stack.yaml
+++ b/stack.yaml
@@ -7,7 +7,7 @@ packages:
   - 'external-stg'
 
 ghc-options:
-  "$everything": -fno-stgbin -fno-stgapp
+  "$everything": -fno-stgbin -fno-stgapp -optcxx-std=c++17
 
 extra-deps:
   - async-pool-0.9.1@sha256:4015140f896c3f1652b06a679b0ade2717d05557970c283ea2c372a71be2a6a1,1605

--- a/stack.yaml
+++ b/stack.yaml
@@ -11,8 +11,8 @@ ghc-options:
 
 extra-deps:
   - async-pool-0.9.1@sha256:4015140f896c3f1652b06a679b0ade2717d05557970c283ea2c372a71be2a6a1,1605
-  - github: csabahruska/souffle-haskell
-    commit: 29925d46da20b20ef6eeb38cb93ba3db797df230
+  - github: luc-tielen/souffle-haskell
+    commit: e4da32f22be4dec293d1ddc13d35fa17d61f008f
 
 # use custom ext-stg whole program compiler GHC
 compiler:     ghc-8.11.0.20200527

--- a/stack.yaml
+++ b/stack.yaml
@@ -12,7 +12,7 @@ ghc-options:
 extra-deps:
   - async-pool-0.9.1@sha256:4015140f896c3f1652b06a679b0ade2717d05557970c283ea2c372a71be2a6a1,1605
   - github: luc-tielen/souffle-haskell
-    commit: e4da32f22be4dec293d1ddc13d35fa17d61f008f
+    commit: e8708b2233fbe1f840b5df903cacc4b9731ed04d
 
 # use custom ext-stg whole program compiler GHC
 compiler:     ghc-8.11.0.20200527


### PR DESCRIPTION
- Regenerated liveness datalog code using souffle 2.0
- Point to a newer souffle-haskell commit (if this also works on your machine, I can make a new release)
- Get rid of TH workarounds previously needed for souffle-haskell

and I also added a .gitignore 😅. I'm not sure about last commit since I'm not familiar with stack/this project; it might be cleaner to add that flag to just the external-stg-compiler cabal file?