### PR TITLE
Upgrade underlying GHC to 8f021b8c474f328441982c90c6a12f716b5607eb

### DIFF
--- a/external-stg-compiler/app/gen-obj.hs
+++ b/external-stg-compiler/app/gen-obj.hs
@@ -18,7 +18,7 @@ import GHC.Paths ( libdir )
 
 {-
   = StgModule
-  { stgUnitId       :: UnitId
+  { stgUnit         :: Unit
   , stgModuleName   :: ModuleName
   , stgModuleTyCons :: [TyCon]
   , stgTopBindings  :: [StgTopBinding]
@@ -45,6 +45,6 @@ main = runGhc (Just libdir) $ do
     --putStrLn $ unlines $ map show stgIdUniqueMap
 
     -- HINT: the stubs are compiled at link time
-    compileToObjectM cg stgUnitId stgModuleName GHC.NoStubs stgModuleTyCons stgTopBindings oName
+    compileToObjectM cg stgUnit stgModuleName GHC.NoStubs stgModuleTyCons stgTopBindings oName
 
     -- TODO: simplify API to: compileToObject cg stgModule oName

--- a/external-stg-compiler/app/gen-obj2.hs
+++ b/external-stg-compiler/app/gen-obj2.hs
@@ -20,7 +20,7 @@ import GHC.Paths ( libdir )
 
 {-
   = StgModule
-  { stgUnitId       :: UnitId
+  { stgUnit         :: Unit
   , stgModuleName   :: ModuleName
   , stgModuleTyCons :: [TyCon]
   , stgTopBindings  :: [StgTopBinding]
@@ -48,4 +48,4 @@ main = do
           oName         = objectOutputPath </> modName ++ ".o"
 
       -- HINT: the stubs are compiled at link time
-      compileToObjectM cg stgUnitId stgModuleName GHC.NoStubs stgModuleTyCons stgTopBindings oName
+      compileToObjectM cg stgUnit stgModuleName GHC.NoStubs stgModuleTyCons stgTopBindings oName

--- a/stack.yaml
+++ b/stack.yaml
@@ -13,6 +13,7 @@ extra-deps:
   - async-pool-0.9.1@sha256:4015140f896c3f1652b06a679b0ade2717d05557970c283ea2c372a71be2a6a1,1605
   - souffle-haskell-1.1.0
   - zip-1.7.0
+  - th-abstraction-0.4.2.0
 
 
 # use custom ext-stg whole program compiler GHC


### PR DESCRIPTION
I've started work on rebasing to GHC 9.0.1. For now, https://gitlab.haskell.org/ghc/ghc/-/issues/20012 blocks that effort. At the very least, this PR straddles some of the big GHC refactorings that happened in the meantime.