### PR TITLE
GHC 9.6+ updates

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,16 +11,15 @@ jobs:
     if: github.ref != 'refs/heads/master'
     steps:
      - uses: DeterminateSystems/nix-installer-action@main
-     - name: Cancel Previous Runs
-       uses: styfle/cancel-workflow-action@0.9.1
-       with:
-         access_token: ${{ github.token }}
 
      - name: Nix channel update
        run: nix-channel --update
 
      - name: Cabal install
        run: nix-env -iA cabal-install -f '<nixpkgs>'
+
+     - name: Cabal update
+       run: cabal update
 
      - name: Build external-stg-interpreter
        run: nix-shell -p ghc -p bzip2.dev -p zlib.dev --run 'cabal build external-stg-interpreter'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,29 @@
+name: GHC-WPC CI
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    if: github.ref != 'refs/heads/master'
+    steps:
+     - uses: DeterminateSystems/nix-installer-action@main
+     - name: Cancel Previous Runs
+       uses: styfle/cancel-workflow-action@0.9.1
+       with:
+         access_token: ${{ github.token }}
+
+     - name: Nix channel update
+       run: nix-channel --update
+
+     - name: Cabal install
+       run: nix-env -iA cabal-install -f '<nixpkgs>'
+
+     - name: Build external-stg-interpreter
+       run: nix-shell -p ghc -p bzip2.dev -p zlib.dev --run 'cabal build external-stg-interpreter'
+
+     - name: Test external-stg-interpreter
+       run: nix-shell -p 'haskellPackages.ghcWithPackages (p: with p; [ hspec-discover ])' --run 'cabal test external-stg-interpreter'

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 **/.stack-work/
+TAGS
+dist-newstyle
+*~

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# GHC whole program compiler project
+# GHC whole program compiler project [![Build Status](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Factions-badge.atrox.dev%2Fgrin-compiler%2Fghc-whole-program-compiler-project%2Fbadge%3Fref%3Dmaster&style=flat-square)](https://actions-badge.atrox.dev/grin-compiler/ghc-whole-program-compiler-project/goto?ref=master)
 
 The project consists of GHC **wpc-plugin** and the corresponding **External STG IR** and **tooling**.
 

--- a/cabal.project
+++ b/cabal.project
@@ -1,0 +1,23 @@
+packages:
+  external-stg/
+  external-stg-syntax/
+  external-stg-interpreter/
+  external-stg-compiler/
+  wpc-plugin/
+  lambda/
+
+package external-stg-interpreter
+  flags: +external-ext-stg-gc
+
+package external-stg-compiler
+  flags: +external-ext-stg-liveness
+
+source-repository-package
+  type: git
+  location: https://github.com/david-christiansen/final-pretty-printer
+  tag: 048e8fa2d8b2b7a6f9e4e209db4f67361321eec8
+
+source-repository-package
+  type: git
+  location: https://github.com/luc-tielen/souffle-haskell
+  tag: 268a11283ca9293b5eacabf7a0b79d9368232478

--- a/external-stg-compiler/.ghci
+++ b/external-stg-compiler/.ghci
@@ -1,0 +1,1 @@
+:set -ilib

--- a/external-stg-compiler/external-stg-compiler.cabal
+++ b/external-stg-compiler/external-stg-compiler.cabal
@@ -12,6 +12,15 @@ copyright:           2020 Csaba Hruska
 category:            Compiler
 build-type:          Simple
 
+flag external-ext-stg-liveness
+  manual:
+    True
+  default:
+    False
+  description:
+    If enabled, the ext-stg-liveness binary is provided externally and available in $PATH
+    Disbled by default.
+
 library
   hs-source-dirs:      lib
   exposed-modules:
@@ -43,13 +52,14 @@ library
   default-language:     Haskell2010
   cpp-options:          -DEXTERNAL_STG_COMPILER_PACKAGE
 
-  include-dirs:         cbits
+  if !flag(external-ext-stg-liveness)
+    include-dirs:         cbits
 
-  extra-libraries:      gomp
+    extra-libraries:      gomp
 
-  cxx-sources:          cbits/ext-stg-liveness.cpp
-  cxx-options:          -D__EMBEDDED_SOUFFLE__ -D_OPENMP -std=c++17
-  ld-options:           "-Wl,--undefined=__factory_Sf_ext_stg_liveness_instance"
+    cxx-sources:          cbits/ext-stg-liveness.cpp
+    cxx-options:          -D__EMBEDDED_SOUFFLE__ -D_OPENMP -std=c++17
+    ld-options:           "-Wl,--undefined=__factory_Sf_ext_stg_liveness_instance"
 
 executable gen-exe
   hs-source-dirs:      app

--- a/external-stg-compiler/lib/Stg/GHC/ToStg.hs
+++ b/external-stg-compiler/lib/Stg/GHC/ToStg.hs
@@ -37,6 +37,7 @@ import GHC.Core.TyCon
 import GHC.Core.DataCon
 import GHC.Core.Type
 
+import Control.Monad
 import Control.Monad.State
 import Data.List (partition)
 

--- a/external-stg-interpreter/.ghci
+++ b/external-stg-interpreter/.ghci
@@ -1,0 +1,1 @@
+:set -ilib

--- a/external-stg-interpreter/datalog/ext-stg-gc.cpp
+++ b/external-stg-interpreter/datalog/ext-stg-gc.cpp
@@ -1,14 +1,17 @@
-
+#define SOUFFLE_GENERATOR_VERSION ""
 #include "souffle/CompiledSouffle.h"
-
+#include "souffle/SignalHandler.h"
+#include "souffle/SouffleInterface.h"
+#include "souffle/datastructure/BTree.h"
+#include "souffle/io/IOSystem.h"
+#include <any>
 namespace functors {
- extern "C" {
+extern "C" {
 }
-}
-
-namespace souffle {
-static const RamDomain RAM_BIT_SHIFT_MASK = RAM_DOMAIN_SIZE - 1;
-struct t_btree_i__0__1 {
+} //namespace functors
+namespace souffle::t_btree_i__0__1 {
+using namespace souffle;
+struct Type {
 static constexpr Relation::arity_type Arity = 1;
 using t_tuple = Tuple<RamDomain, 1>;
 struct t_comparator_0{
@@ -30,50 +33,76 @@ t_ind_0::operation_hints hints_0_lower;
 t_ind_0::operation_hints hints_0_upper;
 };
 context createContext() { return context(); }
-bool insert(const t_tuple& t) {
+bool insert(const t_tuple& t);
+bool insert(const t_tuple& t, context& h);
+bool insert(const RamDomain* ramDomain);
+bool insert(RamDomain a0);
+bool contains(const t_tuple& t, context& h) const;
+bool contains(const t_tuple& t) const;
+std::size_t size() const;
+iterator find(const t_tuple& t, context& h) const;
+iterator find(const t_tuple& t) const;
+range<iterator> lowerUpperRange_0(const t_tuple& /* lower */, const t_tuple& /* upper */, context& /* h */) const;
+range<iterator> lowerUpperRange_0(const t_tuple& /* lower */, const t_tuple& /* upper */) const;
+range<t_ind_0::iterator> lowerUpperRange_1(const t_tuple& lower, const t_tuple& upper, context& h) const;
+range<t_ind_0::iterator> lowerUpperRange_1(const t_tuple& lower, const t_tuple& upper) const;
+bool empty() const;
+std::vector<range<iterator>> partition() const;
+void purge();
+iterator begin() const;
+iterator end() const;
+void printStatistics(std::ostream& o) const;
+};
+} // namespace souffle::t_btree_i__0__1 
+namespace souffle::t_btree_i__0__1 {
+using namespace souffle;
+using t_ind_0 = Type::t_ind_0;
+using iterator = Type::iterator;
+using context = Type::context;
+bool Type::insert(const t_tuple& t) {
 context h;
 return insert(t, h);
 }
-bool insert(const t_tuple& t, context& h) {
+bool Type::insert(const t_tuple& t, context& h) {
 if (ind_0.insert(t, h.hints_0_lower)) {
 return true;
 } else return false;
 }
-bool insert(const RamDomain* ramDomain) {
+bool Type::insert(const RamDomain* ramDomain) {
 RamDomain data[1];
 std::copy(ramDomain, ramDomain + 1, data);
 const t_tuple& tuple = reinterpret_cast<const t_tuple&>(data);
 context h;
 return insert(tuple, h);
 }
-bool insert(RamDomain a0) {
+bool Type::insert(RamDomain a0) {
 RamDomain data[1] = {a0};
 return insert(data);
 }
-bool contains(const t_tuple& t, context& h) const {
+bool Type::contains(const t_tuple& t, context& h) const {
 return ind_0.contains(t, h.hints_0_lower);
 }
-bool contains(const t_tuple& t) const {
+bool Type::contains(const t_tuple& t) const {
 context h;
 return contains(t, h);
 }
-std::size_t size() const {
+std::size_t Type::size() const {
 return ind_0.size();
 }
-iterator find(const t_tuple& t, context& h) const {
+iterator Type::find(const t_tuple& t, context& h) const {
 return ind_0.find(t, h.hints_0_lower);
 }
-iterator find(const t_tuple& t) const {
+iterator Type::find(const t_tuple& t) const {
 context h;
 return find(t, h);
 }
-range<iterator> lowerUpperRange_0(const t_tuple& /* lower */, const t_tuple& /* upper */, context& /* h */) const {
+range<iterator> Type::lowerUpperRange_0(const t_tuple& /* lower */, const t_tuple& /* upper */, context& /* h */) const {
 return range<iterator>(ind_0.begin(),ind_0.end());
 }
-range<iterator> lowerUpperRange_0(const t_tuple& /* lower */, const t_tuple& /* upper */) const {
+range<iterator> Type::lowerUpperRange_0(const t_tuple& /* lower */, const t_tuple& /* upper */) const {
 return range<iterator>(ind_0.begin(),ind_0.end());
 }
-range<t_ind_0::iterator> lowerUpperRange_1(const t_tuple& lower, const t_tuple& upper, context& h) const {
+range<t_ind_0::iterator> Type::lowerUpperRange_1(const t_tuple& lower, const t_tuple& upper, context& h) const {
 t_comparator_0 comparator;
 int cmp = comparator(lower, upper);
 if (cmp == 0) {
@@ -87,31 +116,33 @@ if (cmp > 0) {
 }
 return make_range(ind_0.lower_bound(lower, h.hints_0_lower), ind_0.upper_bound(upper, h.hints_0_upper));
 }
-range<t_ind_0::iterator> lowerUpperRange_1(const t_tuple& lower, const t_tuple& upper) const {
+range<t_ind_0::iterator> Type::lowerUpperRange_1(const t_tuple& lower, const t_tuple& upper) const {
 context h;
 return lowerUpperRange_1(lower,upper,h);
 }
-bool empty() const {
+bool Type::empty() const {
 return ind_0.empty();
 }
-std::vector<range<iterator>> partition() const {
+std::vector<range<iterator>> Type::partition() const {
 return ind_0.getChunks(400);
 }
-void purge() {
+void Type::purge() {
 ind_0.clear();
 }
-iterator begin() const {
+iterator Type::begin() const {
 return ind_0.begin();
 }
-iterator end() const {
+iterator Type::end() const {
 return ind_0.end();
 }
-void printStatistics(std::ostream& o) const {
+void Type::printStatistics(std::ostream& o) const {
 o << " arity 1 direct b-tree index 0 lex-order [0]\n";
 ind_0.printStats(o);
 }
-};
-struct t_btree_ii__0_1__11__10 {
+} // namespace souffle::t_btree_i__0__1 
+namespace souffle::t_btree_ii__0_1__11__10 {
+using namespace souffle;
+struct Type {
 static constexpr Relation::arity_type Arity = 2;
 using t_tuple = Tuple<RamDomain, 2>;
 struct t_comparator_0{
@@ -133,50 +164,78 @@ t_ind_0::operation_hints hints_0_lower;
 t_ind_0::operation_hints hints_0_upper;
 };
 context createContext() { return context(); }
-bool insert(const t_tuple& t) {
+bool insert(const t_tuple& t);
+bool insert(const t_tuple& t, context& h);
+bool insert(const RamDomain* ramDomain);
+bool insert(RamDomain a0,RamDomain a1);
+bool contains(const t_tuple& t, context& h) const;
+bool contains(const t_tuple& t) const;
+std::size_t size() const;
+iterator find(const t_tuple& t, context& h) const;
+iterator find(const t_tuple& t) const;
+range<iterator> lowerUpperRange_00(const t_tuple& /* lower */, const t_tuple& /* upper */, context& /* h */) const;
+range<iterator> lowerUpperRange_00(const t_tuple& /* lower */, const t_tuple& /* upper */) const;
+range<t_ind_0::iterator> lowerUpperRange_11(const t_tuple& lower, const t_tuple& upper, context& h) const;
+range<t_ind_0::iterator> lowerUpperRange_11(const t_tuple& lower, const t_tuple& upper) const;
+range<t_ind_0::iterator> lowerUpperRange_10(const t_tuple& lower, const t_tuple& upper, context& h) const;
+range<t_ind_0::iterator> lowerUpperRange_10(const t_tuple& lower, const t_tuple& upper) const;
+bool empty() const;
+std::vector<range<iterator>> partition() const;
+void purge();
+iterator begin() const;
+iterator end() const;
+void printStatistics(std::ostream& o) const;
+};
+} // namespace souffle::t_btree_ii__0_1__11__10 
+namespace souffle::t_btree_ii__0_1__11__10 {
+using namespace souffle;
+using t_ind_0 = Type::t_ind_0;
+using iterator = Type::iterator;
+using context = Type::context;
+bool Type::insert(const t_tuple& t) {
 context h;
 return insert(t, h);
 }
-bool insert(const t_tuple& t, context& h) {
+bool Type::insert(const t_tuple& t, context& h) {
 if (ind_0.insert(t, h.hints_0_lower)) {
 return true;
 } else return false;
 }
-bool insert(const RamDomain* ramDomain) {
+bool Type::insert(const RamDomain* ramDomain) {
 RamDomain data[2];
 std::copy(ramDomain, ramDomain + 2, data);
 const t_tuple& tuple = reinterpret_cast<const t_tuple&>(data);
 context h;
 return insert(tuple, h);
 }
-bool insert(RamDomain a0,RamDomain a1) {
+bool Type::insert(RamDomain a0,RamDomain a1) {
 RamDomain data[2] = {a0,a1};
 return insert(data);
 }
-bool contains(const t_tuple& t, context& h) const {
+bool Type::contains(const t_tuple& t, context& h) const {
 return ind_0.contains(t, h.hints_0_lower);
 }
-bool contains(const t_tuple& t) const {
+bool Type::contains(const t_tuple& t) const {
 context h;
 return contains(t, h);
 }
-std::size_t size() const {
+std::size_t Type::size() const {
 return ind_0.size();
 }
-iterator find(const t_tuple& t, context& h) const {
+iterator Type::find(const t_tuple& t, context& h) const {
 return ind_0.find(t, h.hints_0_lower);
 }
-iterator find(const t_tuple& t) const {
+iterator Type::find(const t_tuple& t) const {
 context h;
 return find(t, h);
 }
-range<iterator> lowerUpperRange_00(const t_tuple& /* lower */, const t_tuple& /* upper */, context& /* h */) const {
+range<iterator> Type::lowerUpperRange_00(const t_tuple& /* lower */, const t_tuple& /* upper */, context& /* h */) const {
 return range<iterator>(ind_0.begin(),ind_0.end());
 }
-range<iterator> lowerUpperRange_00(const t_tuple& /* lower */, const t_tuple& /* upper */) const {
+range<iterator> Type::lowerUpperRange_00(const t_tuple& /* lower */, const t_tuple& /* upper */) const {
 return range<iterator>(ind_0.begin(),ind_0.end());
 }
-range<t_ind_0::iterator> lowerUpperRange_11(const t_tuple& lower, const t_tuple& upper, context& h) const {
+range<t_ind_0::iterator> Type::lowerUpperRange_11(const t_tuple& lower, const t_tuple& upper, context& h) const {
 t_comparator_0 comparator;
 int cmp = comparator(lower, upper);
 if (cmp == 0) {
@@ -190,11 +249,11 @@ if (cmp > 0) {
 }
 return make_range(ind_0.lower_bound(lower, h.hints_0_lower), ind_0.upper_bound(upper, h.hints_0_upper));
 }
-range<t_ind_0::iterator> lowerUpperRange_11(const t_tuple& lower, const t_tuple& upper) const {
+range<t_ind_0::iterator> Type::lowerUpperRange_11(const t_tuple& lower, const t_tuple& upper) const {
 context h;
 return lowerUpperRange_11(lower,upper,h);
 }
-range<t_ind_0::iterator> lowerUpperRange_10(const t_tuple& lower, const t_tuple& upper, context& h) const {
+range<t_ind_0::iterator> Type::lowerUpperRange_10(const t_tuple& lower, const t_tuple& upper, context& h) const {
 t_comparator_0 comparator;
 int cmp = comparator(lower, upper);
 if (cmp > 0) {
@@ -202,104 +261,634 @@ if (cmp > 0) {
 }
 return make_range(ind_0.lower_bound(lower, h.hints_0_lower), ind_0.upper_bound(upper, h.hints_0_upper));
 }
-range<t_ind_0::iterator> lowerUpperRange_10(const t_tuple& lower, const t_tuple& upper) const {
+range<t_ind_0::iterator> Type::lowerUpperRange_10(const t_tuple& lower, const t_tuple& upper) const {
 context h;
 return lowerUpperRange_10(lower,upper,h);
 }
-bool empty() const {
+bool Type::empty() const {
 return ind_0.empty();
 }
-std::vector<range<iterator>> partition() const {
+std::vector<range<iterator>> Type::partition() const {
 return ind_0.getChunks(400);
 }
-void purge() {
+void Type::purge() {
 ind_0.clear();
 }
-iterator begin() const {
+iterator Type::begin() const {
 return ind_0.begin();
 }
-iterator end() const {
+iterator Type::end() const {
 return ind_0.end();
 }
-void printStatistics(std::ostream& o) const {
+void Type::printStatistics(std::ostream& o) const {
 o << " arity 2 direct b-tree index 0 lex-order [0,1]\n";
 ind_0.printStats(o);
 }
+} // namespace souffle::t_btree_ii__0_1__11__10 
+namespace  souffle {
+using namespace souffle;
+class Stratum_DeadlockingThread_69894afebfc94aee {
+public:
+ Stratum_DeadlockingThread_69894afebfc94aee(SymbolTable& symTable,RecordTable& recordTable,ConcurrentCache<std::string,std::regex>& regexCache,bool& pruneImdtRels,bool& performIO,SignalHandler*& signalHandler,std::atomic<std::size_t>& iter,std::atomic<RamDomain>& ctr,std::string& inputDirectory,std::string& outputDirectory,t_btree_i__0__1::Type& rel_DeadlockingThread_8fa18e0d3ee84b8b,t_btree_i__0__1::Type& rel_LiveStep0_d54eeb7faabc4a13,t_btree_i__0__1::Type& rel_MaybeDeadlockingThread_bdb2bd10c95b5982);
+void run([[maybe_unused]] const std::vector<RamDomain>& args,[[maybe_unused]] std::vector<RamDomain>& ret);
+private:
+SymbolTable& symTable;
+RecordTable& recordTable;
+ConcurrentCache<std::string,std::regex>& regexCache;
+bool& pruneImdtRels;
+bool& performIO;
+SignalHandler*& signalHandler;
+std::atomic<std::size_t>& iter;
+std::atomic<RamDomain>& ctr;
+std::string& inputDirectory;
+std::string& outputDirectory;
+t_btree_i__0__1::Type* rel_DeadlockingThread_8fa18e0d3ee84b8b;
+t_btree_i__0__1::Type* rel_LiveStep0_d54eeb7faabc4a13;
+t_btree_i__0__1::Type* rel_MaybeDeadlockingThread_bdb2bd10c95b5982;
 };
-
-class Sf_ext_stg_gc : public SouffleProgram {
-private:
-static inline std::string substr_wrapper(const std::string& str, std::size_t idx, std::size_t len) {
-   std::string result; 
-   try { result = str.substr(idx,len); } catch(...) { 
-     std::cerr << "warning: wrong index position provided by substr(\"";
-     std::cerr << str << "\"," << (int32_t)idx << "," << (int32_t)len << ") functor.\n";
-   } return result;
+} // namespace  souffle
+namespace  souffle {
+using namespace souffle;
+ Stratum_DeadlockingThread_69894afebfc94aee::Stratum_DeadlockingThread_69894afebfc94aee(SymbolTable& symTable,RecordTable& recordTable,ConcurrentCache<std::string,std::regex>& regexCache,bool& pruneImdtRels,bool& performIO,SignalHandler*& signalHandler,std::atomic<std::size_t>& iter,std::atomic<RamDomain>& ctr,std::string& inputDirectory,std::string& outputDirectory,t_btree_i__0__1::Type& rel_DeadlockingThread_8fa18e0d3ee84b8b,t_btree_i__0__1::Type& rel_LiveStep0_d54eeb7faabc4a13,t_btree_i__0__1::Type& rel_MaybeDeadlockingThread_bdb2bd10c95b5982):
+symTable(symTable),
+recordTable(recordTable),
+regexCache(regexCache),
+pruneImdtRels(pruneImdtRels),
+performIO(performIO),
+signalHandler(signalHandler),
+iter(iter),
+ctr(ctr),
+inputDirectory(inputDirectory),
+outputDirectory(outputDirectory),
+rel_DeadlockingThread_8fa18e0d3ee84b8b(&rel_DeadlockingThread_8fa18e0d3ee84b8b),
+rel_LiveStep0_d54eeb7faabc4a13(&rel_LiveStep0_d54eeb7faabc4a13),
+rel_MaybeDeadlockingThread_bdb2bd10c95b5982(&rel_MaybeDeadlockingThread_bdb2bd10c95b5982){
 }
+
+void Stratum_DeadlockingThread_69894afebfc94aee::run([[maybe_unused]] const std::vector<RamDomain>& args,[[maybe_unused]] std::vector<RamDomain>& ret){
+signalHandler->setMsg(R"_(DeadlockingThread(tid) :- 
+   MaybeDeadlockingThread(tid),
+   !LiveStep0(tid).
+in file ext-stg-gc.dl [38:1-40:19])_");
+if(!(rel_MaybeDeadlockingThread_bdb2bd10c95b5982->empty())) {
+[&](){
+auto part = rel_MaybeDeadlockingThread_bdb2bd10c95b5982->partition();
+PARALLEL_START
+CREATE_OP_CONTEXT(rel_DeadlockingThread_8fa18e0d3ee84b8b_op_ctxt,rel_DeadlockingThread_8fa18e0d3ee84b8b->createContext());
+CREATE_OP_CONTEXT(rel_LiveStep0_d54eeb7faabc4a13_op_ctxt,rel_LiveStep0_d54eeb7faabc4a13->createContext());
+CREATE_OP_CONTEXT(rel_MaybeDeadlockingThread_bdb2bd10c95b5982_op_ctxt,rel_MaybeDeadlockingThread_bdb2bd10c95b5982->createContext());
+
+                   #if defined _OPENMP && _OPENMP < 200805
+                           auto count = std::distance(part.begin(), part.end());
+                           auto base = part.begin();
+                           pfor(int index  = 0; index < count; index++) {
+                               auto it = base + index;
+                   #else
+                           pfor(auto it = part.begin(); it < part.end(); it++) {
+                   #endif
+                   try{
+for(const auto& env0 : *it) {
+if( !(rel_LiveStep0_d54eeb7faabc4a13->contains(Tuple<RamDomain,1>{{ramBitCast(env0[0])}},READ_OP_CONTEXT(rel_LiveStep0_d54eeb7faabc4a13_op_ctxt)))) {
+Tuple<RamDomain,1> tuple{{ramBitCast(env0[0])}};
+rel_DeadlockingThread_8fa18e0d3ee84b8b->insert(tuple,READ_OP_CONTEXT(rel_DeadlockingThread_8fa18e0d3ee84b8b_op_ctxt));
+}
+}
+} catch(std::exception &e) { signalHandler->error(e.what());}
+}
+PARALLEL_END
+}
+();}
+if (performIO) {
+try {std::map<std::string, std::string> directiveMap({{"IO","file"},{"attributeNames","threadId"},{"auxArity","0"},{"name","DeadlockingThread"},{"operation","output"},{"output-dir","."},{"params","{\"records\": {}, \"relation\": {\"arity\": 1, \"params\": [\"threadId\"]}}"},{"types","{\"ADTs\": {}, \"records\": {}, \"relation\": {\"arity\": 1, \"types\": [\"s:symbol\"]}}"}});
+if (outputDirectory == "-"){directiveMap["IO"] = "stdout"; directiveMap["headers"] = "true";}
+else if (!outputDirectory.empty()) {directiveMap["output-dir"] = outputDirectory;}
+IOSystem::getInstance().getWriter(directiveMap, symTable, recordTable)->writeAll(*rel_DeadlockingThread_8fa18e0d3ee84b8b);
+} catch (std::exception& e) {std::cerr << e.what();exit(1);}
+}
+if (pruneImdtRels) rel_MaybeDeadlockingThread_bdb2bd10c95b5982->purge();
+}
+
+} // namespace  souffle
+
+namespace  souffle {
+using namespace souffle;
+class Stratum_GCRoot_b08a674c48c5fe0e {
 public:
-// -- initialize symbol table --
-SymbolTableImpl symTable;// -- initialize record table --
-SpecializedRecordTable<0> recordTable{};
-// -- Table: GCRoot
-Own<t_btree_i__0__1> rel_1_GCRoot = mk<t_btree_i__0__1>();
-souffle::RelationWrapper<t_btree_i__0__1> wrapper_rel_1_GCRoot;
-// -- Table: Reference
-Own<t_btree_ii__0_1__11__10> rel_2_Reference = mk<t_btree_ii__0_1__11__10>();
-souffle::RelationWrapper<t_btree_ii__0_1__11__10> wrapper_rel_2_Reference;
-// -- Table: LiveStep0
-Own<t_btree_i__0__1> rel_3_LiveStep0 = mk<t_btree_i__0__1>();
-souffle::RelationWrapper<t_btree_i__0__1> wrapper_rel_3_LiveStep0;
-// -- Table: @delta_LiveStep0
-Own<t_btree_i__0__1> rel_4_delta_LiveStep0 = mk<t_btree_i__0__1>();
-// -- Table: @new_LiveStep0
-Own<t_btree_i__0__1> rel_5_new_LiveStep0 = mk<t_btree_i__0__1>();
-// -- Table: MaybeDeadlockingThread
-Own<t_btree_i__0__1> rel_6_MaybeDeadlockingThread = mk<t_btree_i__0__1>();
-souffle::RelationWrapper<t_btree_i__0__1> wrapper_rel_6_MaybeDeadlockingThread;
-// -- Table: DeadlockingThread
-Own<t_btree_i__0__1> rel_7_DeadlockingThread = mk<t_btree_i__0__1>();
-souffle::RelationWrapper<t_btree_i__0__1> wrapper_rel_7_DeadlockingThread;
-// -- Table: Live
-Own<t_btree_i__0__1> rel_8_Live = mk<t_btree_i__0__1>();
-souffle::RelationWrapper<t_btree_i__0__1> wrapper_rel_8_Live;
-// -- Table: @delta_Live
-Own<t_btree_i__0__1> rel_9_delta_Live = mk<t_btree_i__0__1>();
-// -- Table: @new_Live
-Own<t_btree_i__0__1> rel_10_new_Live = mk<t_btree_i__0__1>();
-public:
-Sf_ext_stg_gc()
-: wrapper_rel_1_GCRoot(0, *rel_1_GCRoot, *this, "GCRoot", std::array<const char *,1>{{"s:symbol"}}, std::array<const char *,1>{{"val"}}, 0)
-, wrapper_rel_2_Reference(1, *rel_2_Reference, *this, "Reference", std::array<const char *,2>{{"s:symbol","s:symbol"}}, std::array<const char *,2>{{"from","to"}}, 0)
-, wrapper_rel_3_LiveStep0(2, *rel_3_LiveStep0, *this, "LiveStep0", std::array<const char *,1>{{"s:symbol"}}, std::array<const char *,1>{{"val"}}, 0)
-, wrapper_rel_6_MaybeDeadlockingThread(3, *rel_6_MaybeDeadlockingThread, *this, "MaybeDeadlockingThread", std::array<const char *,1>{{"s:symbol"}}, std::array<const char *,1>{{"threadId"}}, 0)
-, wrapper_rel_7_DeadlockingThread(4, *rel_7_DeadlockingThread, *this, "DeadlockingThread", std::array<const char *,1>{{"s:symbol"}}, std::array<const char *,1>{{"threadId"}}, 0)
-, wrapper_rel_8_Live(5, *rel_8_Live, *this, "Live", std::array<const char *,1>{{"s:symbol"}}, std::array<const char *,1>{{"val"}}, 0)
-{
-addRelation("GCRoot", wrapper_rel_1_GCRoot, true, false);
-addRelation("Reference", wrapper_rel_2_Reference, true, false);
-addRelation("LiveStep0", wrapper_rel_3_LiveStep0, false, false);
-addRelation("MaybeDeadlockingThread", wrapper_rel_6_MaybeDeadlockingThread, true, false);
-addRelation("DeadlockingThread", wrapper_rel_7_DeadlockingThread, false, true);
-addRelation("Live", wrapper_rel_8_Live, false, true);
-}
-~Sf_ext_stg_gc() {
-}
-
+ Stratum_GCRoot_b08a674c48c5fe0e(SymbolTable& symTable,RecordTable& recordTable,ConcurrentCache<std::string,std::regex>& regexCache,bool& pruneImdtRels,bool& performIO,SignalHandler*& signalHandler,std::atomic<std::size_t>& iter,std::atomic<RamDomain>& ctr,std::string& inputDirectory,std::string& outputDirectory,t_btree_i__0__1::Type& rel_GCRoot_f9754bdf5b76c5df);
+void run([[maybe_unused]] const std::vector<RamDomain>& args,[[maybe_unused]] std::vector<RamDomain>& ret);
 private:
-std::string             inputDirectory;
-std::string             outputDirectory;
-SignalHandler*          signalHandler {SignalHandler::instance()};
-std::atomic<RamDomain>  ctr {};
-std::atomic<std::size_t>     iter {};
+SymbolTable& symTable;
+RecordTable& recordTable;
+ConcurrentCache<std::string,std::regex>& regexCache;
+bool& pruneImdtRels;
+bool& performIO;
+SignalHandler*& signalHandler;
+std::atomic<std::size_t>& iter;
+std::atomic<RamDomain>& ctr;
+std::string& inputDirectory;
+std::string& outputDirectory;
+t_btree_i__0__1::Type* rel_GCRoot_f9754bdf5b76c5df;
+};
+} // namespace  souffle
+namespace  souffle {
+using namespace souffle;
+ Stratum_GCRoot_b08a674c48c5fe0e::Stratum_GCRoot_b08a674c48c5fe0e(SymbolTable& symTable,RecordTable& recordTable,ConcurrentCache<std::string,std::regex>& regexCache,bool& pruneImdtRels,bool& performIO,SignalHandler*& signalHandler,std::atomic<std::size_t>& iter,std::atomic<RamDomain>& ctr,std::string& inputDirectory,std::string& outputDirectory,t_btree_i__0__1::Type& rel_GCRoot_f9754bdf5b76c5df):
+symTable(symTable),
+recordTable(recordTable),
+regexCache(regexCache),
+pruneImdtRels(pruneImdtRels),
+performIO(performIO),
+signalHandler(signalHandler),
+iter(iter),
+ctr(ctr),
+inputDirectory(inputDirectory),
+outputDirectory(outputDirectory),
+rel_GCRoot_f9754bdf5b76c5df(&rel_GCRoot_f9754bdf5b76c5df){
+}
 
-void runFunction(std::string  inputDirectoryArg,
-                 std::string  outputDirectoryArg,
-                 bool         performIOArg,
-                 bool         pruneImdtRelsArg) {
+void Stratum_GCRoot_b08a674c48c5fe0e::run([[maybe_unused]] const std::vector<RamDomain>& args,[[maybe_unused]] std::vector<RamDomain>& ret){
+if (performIO) {
+try {std::map<std::string, std::string> directiveMap({{"IO","file"},{"attributeNames","val"},{"auxArity","0"},{"fact-dir","."},{"name","GCRoot"},{"operation","input"},{"params","{\"records\": {}, \"relation\": {\"arity\": 1, \"params\": [\"val\"]}}"},{"types","{\"ADTs\": {}, \"records\": {}, \"relation\": {\"arity\": 1, \"types\": [\"s:symbol\"]}}"}});
+if (!inputDirectory.empty()) {directiveMap["fact-dir"] = inputDirectory;}
+IOSystem::getInstance().getReader(directiveMap, symTable, recordTable)->readAll(*rel_GCRoot_f9754bdf5b76c5df);
+} catch (std::exception& e) {std::cerr << "Error loading GCRoot data: " << e.what() << '\n';
+exit(1);
+}
+}
+}
+
+} // namespace  souffle
+
+namespace  souffle {
+using namespace souffle;
+class Stratum_Live_b9069971975f423e {
+public:
+ Stratum_Live_b9069971975f423e(SymbolTable& symTable,RecordTable& recordTable,ConcurrentCache<std::string,std::regex>& regexCache,bool& pruneImdtRels,bool& performIO,SignalHandler*& signalHandler,std::atomic<std::size_t>& iter,std::atomic<RamDomain>& ctr,std::string& inputDirectory,std::string& outputDirectory,t_btree_i__0__1::Type& rel_delta_Live_2c57e9662e50a2a0,t_btree_i__0__1::Type& rel_new_Live_ca472dbac4201e48,t_btree_i__0__1::Type& rel_DeadlockingThread_8fa18e0d3ee84b8b,t_btree_i__0__1::Type& rel_Live_2818460375647c67,t_btree_i__0__1::Type& rel_LiveStep0_d54eeb7faabc4a13,t_btree_ii__0_1__11__10::Type& rel_Reference_c57e388e43703de5);
+void run([[maybe_unused]] const std::vector<RamDomain>& args,[[maybe_unused]] std::vector<RamDomain>& ret);
+private:
+SymbolTable& symTable;
+RecordTable& recordTable;
+ConcurrentCache<std::string,std::regex>& regexCache;
+bool& pruneImdtRels;
+bool& performIO;
+SignalHandler*& signalHandler;
+std::atomic<std::size_t>& iter;
+std::atomic<RamDomain>& ctr;
+std::string& inputDirectory;
+std::string& outputDirectory;
+t_btree_i__0__1::Type* rel_delta_Live_2c57e9662e50a2a0;
+t_btree_i__0__1::Type* rel_new_Live_ca472dbac4201e48;
+t_btree_i__0__1::Type* rel_DeadlockingThread_8fa18e0d3ee84b8b;
+t_btree_i__0__1::Type* rel_Live_2818460375647c67;
+t_btree_i__0__1::Type* rel_LiveStep0_d54eeb7faabc4a13;
+t_btree_ii__0_1__11__10::Type* rel_Reference_c57e388e43703de5;
+};
+} // namespace  souffle
+namespace  souffle {
+using namespace souffle;
+ Stratum_Live_b9069971975f423e::Stratum_Live_b9069971975f423e(SymbolTable& symTable,RecordTable& recordTable,ConcurrentCache<std::string,std::regex>& regexCache,bool& pruneImdtRels,bool& performIO,SignalHandler*& signalHandler,std::atomic<std::size_t>& iter,std::atomic<RamDomain>& ctr,std::string& inputDirectory,std::string& outputDirectory,t_btree_i__0__1::Type& rel_delta_Live_2c57e9662e50a2a0,t_btree_i__0__1::Type& rel_new_Live_ca472dbac4201e48,t_btree_i__0__1::Type& rel_DeadlockingThread_8fa18e0d3ee84b8b,t_btree_i__0__1::Type& rel_Live_2818460375647c67,t_btree_i__0__1::Type& rel_LiveStep0_d54eeb7faabc4a13,t_btree_ii__0_1__11__10::Type& rel_Reference_c57e388e43703de5):
+symTable(symTable),
+recordTable(recordTable),
+regexCache(regexCache),
+pruneImdtRels(pruneImdtRels),
+performIO(performIO),
+signalHandler(signalHandler),
+iter(iter),
+ctr(ctr),
+inputDirectory(inputDirectory),
+outputDirectory(outputDirectory),
+rel_delta_Live_2c57e9662e50a2a0(&rel_delta_Live_2c57e9662e50a2a0),
+rel_new_Live_ca472dbac4201e48(&rel_new_Live_ca472dbac4201e48),
+rel_DeadlockingThread_8fa18e0d3ee84b8b(&rel_DeadlockingThread_8fa18e0d3ee84b8b),
+rel_Live_2818460375647c67(&rel_Live_2818460375647c67),
+rel_LiveStep0_d54eeb7faabc4a13(&rel_LiveStep0_d54eeb7faabc4a13),
+rel_Reference_c57e388e43703de5(&rel_Reference_c57e388e43703de5){
+}
+
+void Stratum_Live_b9069971975f423e::run([[maybe_unused]] const std::vector<RamDomain>& args,[[maybe_unused]] std::vector<RamDomain>& ret){
+signalHandler->setMsg(R"_(Live(tid) :- 
+   DeadlockingThread(tid).
+in file ext-stg-gc.dl [42:1-42:37])_");
+if(!(rel_DeadlockingThread_8fa18e0d3ee84b8b->empty())) {
+[&](){
+CREATE_OP_CONTEXT(rel_DeadlockingThread_8fa18e0d3ee84b8b_op_ctxt,rel_DeadlockingThread_8fa18e0d3ee84b8b->createContext());
+CREATE_OP_CONTEXT(rel_Live_2818460375647c67_op_ctxt,rel_Live_2818460375647c67->createContext());
+for(const auto& env0 : *rel_DeadlockingThread_8fa18e0d3ee84b8b) {
+Tuple<RamDomain,1> tuple{{ramBitCast(env0[0])}};
+rel_Live_2818460375647c67->insert(tuple,READ_OP_CONTEXT(rel_Live_2818460375647c67_op_ctxt));
+}
+}
+();}
+signalHandler->setMsg(R"_(Live(ref) :- 
+   LiveStep0(ref).
+in file ext-stg-gc.dl [43:1-43:29])_");
+if(!(rel_LiveStep0_d54eeb7faabc4a13->empty())) {
+[&](){
+CREATE_OP_CONTEXT(rel_Live_2818460375647c67_op_ctxt,rel_Live_2818460375647c67->createContext());
+CREATE_OP_CONTEXT(rel_LiveStep0_d54eeb7faabc4a13_op_ctxt,rel_LiveStep0_d54eeb7faabc4a13->createContext());
+for(const auto& env0 : *rel_LiveStep0_d54eeb7faabc4a13) {
+Tuple<RamDomain,1> tuple{{ramBitCast(env0[0])}};
+rel_Live_2818460375647c67->insert(tuple,READ_OP_CONTEXT(rel_Live_2818460375647c67_op_ctxt));
+}
+}
+();}
+[&](){
+CREATE_OP_CONTEXT(rel_delta_Live_2c57e9662e50a2a0_op_ctxt,rel_delta_Live_2c57e9662e50a2a0->createContext());
+CREATE_OP_CONTEXT(rel_Live_2818460375647c67_op_ctxt,rel_Live_2818460375647c67->createContext());
+for(const auto& env0 : *rel_Live_2818460375647c67) {
+Tuple<RamDomain,1> tuple{{ramBitCast(env0[0])}};
+rel_delta_Live_2c57e9662e50a2a0->insert(tuple,READ_OP_CONTEXT(rel_delta_Live_2c57e9662e50a2a0_op_ctxt));
+}
+}
+();auto loop_counter = RamUnsigned(1);
+iter = 0;
+for(;;) {
+signalHandler->setMsg(R"_(Live(to) :- 
+   Live(from),
+   Reference(from,to).
+in file ext-stg-gc.dl [44:1-46:23])_");
+if(!(rel_delta_Live_2c57e9662e50a2a0->empty()) && !(rel_Reference_c57e388e43703de5->empty())) {
+[&](){
+auto part = rel_delta_Live_2c57e9662e50a2a0->partition();
+PARALLEL_START
+CREATE_OP_CONTEXT(rel_delta_Live_2c57e9662e50a2a0_op_ctxt,rel_delta_Live_2c57e9662e50a2a0->createContext());
+CREATE_OP_CONTEXT(rel_new_Live_ca472dbac4201e48_op_ctxt,rel_new_Live_ca472dbac4201e48->createContext());
+CREATE_OP_CONTEXT(rel_Live_2818460375647c67_op_ctxt,rel_Live_2818460375647c67->createContext());
+CREATE_OP_CONTEXT(rel_Reference_c57e388e43703de5_op_ctxt,rel_Reference_c57e388e43703de5->createContext());
+
+                   #if defined _OPENMP && _OPENMP < 200805
+                           auto count = std::distance(part.begin(), part.end());
+                           auto base = part.begin();
+                           pfor(int index  = 0; index < count; index++) {
+                               auto it = base + index;
+                   #else
+                           pfor(auto it = part.begin(); it < part.end(); it++) {
+                   #endif
+                   try{
+for(const auto& env0 : *it) {
+auto range = rel_Reference_c57e388e43703de5->lowerUpperRange_10(Tuple<RamDomain,2>{{ramBitCast(env0[0]), ramBitCast<RamDomain>(MIN_RAM_SIGNED)}},Tuple<RamDomain,2>{{ramBitCast(env0[0]), ramBitCast<RamDomain>(MAX_RAM_SIGNED)}},READ_OP_CONTEXT(rel_Reference_c57e388e43703de5_op_ctxt));
+for(const auto& env1 : range) {
+if( !(rel_Live_2818460375647c67->contains(Tuple<RamDomain,1>{{ramBitCast(env1[1])}},READ_OP_CONTEXT(rel_Live_2818460375647c67_op_ctxt)))) {
+Tuple<RamDomain,1> tuple{{ramBitCast(env1[1])}};
+rel_new_Live_ca472dbac4201e48->insert(tuple,READ_OP_CONTEXT(rel_new_Live_ca472dbac4201e48_op_ctxt));
+}
+}
+}
+} catch(std::exception &e) { signalHandler->error(e.what());}
+}
+PARALLEL_END
+}
+();}
+if(rel_new_Live_ca472dbac4201e48->empty()) break;
+[&](){
+CREATE_OP_CONTEXT(rel_new_Live_ca472dbac4201e48_op_ctxt,rel_new_Live_ca472dbac4201e48->createContext());
+CREATE_OP_CONTEXT(rel_Live_2818460375647c67_op_ctxt,rel_Live_2818460375647c67->createContext());
+for(const auto& env0 : *rel_new_Live_ca472dbac4201e48) {
+Tuple<RamDomain,1> tuple{{ramBitCast(env0[0])}};
+rel_Live_2818460375647c67->insert(tuple,READ_OP_CONTEXT(rel_Live_2818460375647c67_op_ctxt));
+}
+}
+();std::swap(rel_delta_Live_2c57e9662e50a2a0, rel_new_Live_ca472dbac4201e48);
+rel_new_Live_ca472dbac4201e48->purge();
+loop_counter = (ramBitCast<RamUnsigned>(loop_counter) + ramBitCast<RamUnsigned>(RamUnsigned(1)));
+iter++;
+}
+iter = 0;
+rel_delta_Live_2c57e9662e50a2a0->purge();
+rel_new_Live_ca472dbac4201e48->purge();
+if (performIO) {
+try {std::map<std::string, std::string> directiveMap({{"IO","file"},{"attributeNames","val"},{"auxArity","0"},{"name","Live"},{"operation","output"},{"output-dir","."},{"params","{\"records\": {}, \"relation\": {\"arity\": 1, \"params\": [\"val\"]}}"},{"types","{\"ADTs\": {}, \"records\": {}, \"relation\": {\"arity\": 1, \"types\": [\"s:symbol\"]}}"}});
+if (outputDirectory == "-"){directiveMap["IO"] = "stdout"; directiveMap["headers"] = "true";}
+else if (!outputDirectory.empty()) {directiveMap["output-dir"] = outputDirectory;}
+IOSystem::getInstance().getWriter(directiveMap, symTable, recordTable)->writeAll(*rel_Live_2818460375647c67);
+} catch (std::exception& e) {std::cerr << e.what();exit(1);}
+}
+if (pruneImdtRels) rel_LiveStep0_d54eeb7faabc4a13->purge();
+if (pruneImdtRels) rel_Reference_c57e388e43703de5->purge();
+}
+
+} // namespace  souffle
+
+namespace  souffle {
+using namespace souffle;
+class Stratum_LiveStep0_41822abe1018780c {
+public:
+ Stratum_LiveStep0_41822abe1018780c(SymbolTable& symTable,RecordTable& recordTable,ConcurrentCache<std::string,std::regex>& regexCache,bool& pruneImdtRels,bool& performIO,SignalHandler*& signalHandler,std::atomic<std::size_t>& iter,std::atomic<RamDomain>& ctr,std::string& inputDirectory,std::string& outputDirectory,t_btree_i__0__1::Type& rel_delta_LiveStep0_749758939b4491e5,t_btree_i__0__1::Type& rel_new_LiveStep0_b9970262b9a948e9,t_btree_i__0__1::Type& rel_GCRoot_f9754bdf5b76c5df,t_btree_i__0__1::Type& rel_LiveStep0_d54eeb7faabc4a13,t_btree_ii__0_1__11__10::Type& rel_Reference_c57e388e43703de5);
+void run([[maybe_unused]] const std::vector<RamDomain>& args,[[maybe_unused]] std::vector<RamDomain>& ret);
+private:
+SymbolTable& symTable;
+RecordTable& recordTable;
+ConcurrentCache<std::string,std::regex>& regexCache;
+bool& pruneImdtRels;
+bool& performIO;
+SignalHandler*& signalHandler;
+std::atomic<std::size_t>& iter;
+std::atomic<RamDomain>& ctr;
+std::string& inputDirectory;
+std::string& outputDirectory;
+t_btree_i__0__1::Type* rel_delta_LiveStep0_749758939b4491e5;
+t_btree_i__0__1::Type* rel_new_LiveStep0_b9970262b9a948e9;
+t_btree_i__0__1::Type* rel_GCRoot_f9754bdf5b76c5df;
+t_btree_i__0__1::Type* rel_LiveStep0_d54eeb7faabc4a13;
+t_btree_ii__0_1__11__10::Type* rel_Reference_c57e388e43703de5;
+};
+} // namespace  souffle
+namespace  souffle {
+using namespace souffle;
+ Stratum_LiveStep0_41822abe1018780c::Stratum_LiveStep0_41822abe1018780c(SymbolTable& symTable,RecordTable& recordTable,ConcurrentCache<std::string,std::regex>& regexCache,bool& pruneImdtRels,bool& performIO,SignalHandler*& signalHandler,std::atomic<std::size_t>& iter,std::atomic<RamDomain>& ctr,std::string& inputDirectory,std::string& outputDirectory,t_btree_i__0__1::Type& rel_delta_LiveStep0_749758939b4491e5,t_btree_i__0__1::Type& rel_new_LiveStep0_b9970262b9a948e9,t_btree_i__0__1::Type& rel_GCRoot_f9754bdf5b76c5df,t_btree_i__0__1::Type& rel_LiveStep0_d54eeb7faabc4a13,t_btree_ii__0_1__11__10::Type& rel_Reference_c57e388e43703de5):
+symTable(symTable),
+recordTable(recordTable),
+regexCache(regexCache),
+pruneImdtRels(pruneImdtRels),
+performIO(performIO),
+signalHandler(signalHandler),
+iter(iter),
+ctr(ctr),
+inputDirectory(inputDirectory),
+outputDirectory(outputDirectory),
+rel_delta_LiveStep0_749758939b4491e5(&rel_delta_LiveStep0_749758939b4491e5),
+rel_new_LiveStep0_b9970262b9a948e9(&rel_new_LiveStep0_b9970262b9a948e9),
+rel_GCRoot_f9754bdf5b76c5df(&rel_GCRoot_f9754bdf5b76c5df),
+rel_LiveStep0_d54eeb7faabc4a13(&rel_LiveStep0_d54eeb7faabc4a13),
+rel_Reference_c57e388e43703de5(&rel_Reference_c57e388e43703de5){
+}
+
+void Stratum_LiveStep0_41822abe1018780c::run([[maybe_unused]] const std::vector<RamDomain>& args,[[maybe_unused]] std::vector<RamDomain>& ret){
+signalHandler->setMsg(R"_(LiveStep0(ref) :- 
+   GCRoot(ref).
+in file ext-stg-gc.dl [24:1-24:31])_");
+if(!(rel_GCRoot_f9754bdf5b76c5df->empty())) {
+[&](){
+CREATE_OP_CONTEXT(rel_GCRoot_f9754bdf5b76c5df_op_ctxt,rel_GCRoot_f9754bdf5b76c5df->createContext());
+CREATE_OP_CONTEXT(rel_LiveStep0_d54eeb7faabc4a13_op_ctxt,rel_LiveStep0_d54eeb7faabc4a13->createContext());
+for(const auto& env0 : *rel_GCRoot_f9754bdf5b76c5df) {
+Tuple<RamDomain,1> tuple{{ramBitCast(env0[0])}};
+rel_LiveStep0_d54eeb7faabc4a13->insert(tuple,READ_OP_CONTEXT(rel_LiveStep0_d54eeb7faabc4a13_op_ctxt));
+}
+}
+();}
+[&](){
+CREATE_OP_CONTEXT(rel_delta_LiveStep0_749758939b4491e5_op_ctxt,rel_delta_LiveStep0_749758939b4491e5->createContext());
+CREATE_OP_CONTEXT(rel_LiveStep0_d54eeb7faabc4a13_op_ctxt,rel_LiveStep0_d54eeb7faabc4a13->createContext());
+for(const auto& env0 : *rel_LiveStep0_d54eeb7faabc4a13) {
+Tuple<RamDomain,1> tuple{{ramBitCast(env0[0])}};
+rel_delta_LiveStep0_749758939b4491e5->insert(tuple,READ_OP_CONTEXT(rel_delta_LiveStep0_749758939b4491e5_op_ctxt));
+}
+}
+();auto loop_counter = RamUnsigned(1);
+iter = 0;
+for(;;) {
+signalHandler->setMsg(R"_(LiveStep0(to) :- 
+   LiveStep0(from),
+   Reference(from,to).
+in file ext-stg-gc.dl [26:1-28:23])_");
+if(!(rel_delta_LiveStep0_749758939b4491e5->empty()) && !(rel_Reference_c57e388e43703de5->empty())) {
+[&](){
+auto part = rel_delta_LiveStep0_749758939b4491e5->partition();
+PARALLEL_START
+CREATE_OP_CONTEXT(rel_delta_LiveStep0_749758939b4491e5_op_ctxt,rel_delta_LiveStep0_749758939b4491e5->createContext());
+CREATE_OP_CONTEXT(rel_new_LiveStep0_b9970262b9a948e9_op_ctxt,rel_new_LiveStep0_b9970262b9a948e9->createContext());
+CREATE_OP_CONTEXT(rel_LiveStep0_d54eeb7faabc4a13_op_ctxt,rel_LiveStep0_d54eeb7faabc4a13->createContext());
+CREATE_OP_CONTEXT(rel_Reference_c57e388e43703de5_op_ctxt,rel_Reference_c57e388e43703de5->createContext());
+
+                   #if defined _OPENMP && _OPENMP < 200805
+                           auto count = std::distance(part.begin(), part.end());
+                           auto base = part.begin();
+                           pfor(int index  = 0; index < count; index++) {
+                               auto it = base + index;
+                   #else
+                           pfor(auto it = part.begin(); it < part.end(); it++) {
+                   #endif
+                   try{
+for(const auto& env0 : *it) {
+auto range = rel_Reference_c57e388e43703de5->lowerUpperRange_10(Tuple<RamDomain,2>{{ramBitCast(env0[0]), ramBitCast<RamDomain>(MIN_RAM_SIGNED)}},Tuple<RamDomain,2>{{ramBitCast(env0[0]), ramBitCast<RamDomain>(MAX_RAM_SIGNED)}},READ_OP_CONTEXT(rel_Reference_c57e388e43703de5_op_ctxt));
+for(const auto& env1 : range) {
+if( !(rel_LiveStep0_d54eeb7faabc4a13->contains(Tuple<RamDomain,1>{{ramBitCast(env1[1])}},READ_OP_CONTEXT(rel_LiveStep0_d54eeb7faabc4a13_op_ctxt)))) {
+Tuple<RamDomain,1> tuple{{ramBitCast(env1[1])}};
+rel_new_LiveStep0_b9970262b9a948e9->insert(tuple,READ_OP_CONTEXT(rel_new_LiveStep0_b9970262b9a948e9_op_ctxt));
+}
+}
+}
+} catch(std::exception &e) { signalHandler->error(e.what());}
+}
+PARALLEL_END
+}
+();}
+if(rel_new_LiveStep0_b9970262b9a948e9->empty()) break;
+[&](){
+CREATE_OP_CONTEXT(rel_new_LiveStep0_b9970262b9a948e9_op_ctxt,rel_new_LiveStep0_b9970262b9a948e9->createContext());
+CREATE_OP_CONTEXT(rel_LiveStep0_d54eeb7faabc4a13_op_ctxt,rel_LiveStep0_d54eeb7faabc4a13->createContext());
+for(const auto& env0 : *rel_new_LiveStep0_b9970262b9a948e9) {
+Tuple<RamDomain,1> tuple{{ramBitCast(env0[0])}};
+rel_LiveStep0_d54eeb7faabc4a13->insert(tuple,READ_OP_CONTEXT(rel_LiveStep0_d54eeb7faabc4a13_op_ctxt));
+}
+}
+();std::swap(rel_delta_LiveStep0_749758939b4491e5, rel_new_LiveStep0_b9970262b9a948e9);
+rel_new_LiveStep0_b9970262b9a948e9->purge();
+loop_counter = (ramBitCast<RamUnsigned>(loop_counter) + ramBitCast<RamUnsigned>(RamUnsigned(1)));
+iter++;
+}
+iter = 0;
+rel_delta_LiveStep0_749758939b4491e5->purge();
+rel_new_LiveStep0_b9970262b9a948e9->purge();
+if (pruneImdtRels) rel_GCRoot_f9754bdf5b76c5df->purge();
+}
+
+} // namespace  souffle
+
+namespace  souffle {
+using namespace souffle;
+class Stratum_MaybeDeadlockingThread_fd0c8181097ea422 {
+public:
+ Stratum_MaybeDeadlockingThread_fd0c8181097ea422(SymbolTable& symTable,RecordTable& recordTable,ConcurrentCache<std::string,std::regex>& regexCache,bool& pruneImdtRels,bool& performIO,SignalHandler*& signalHandler,std::atomic<std::size_t>& iter,std::atomic<RamDomain>& ctr,std::string& inputDirectory,std::string& outputDirectory,t_btree_i__0__1::Type& rel_MaybeDeadlockingThread_bdb2bd10c95b5982);
+void run([[maybe_unused]] const std::vector<RamDomain>& args,[[maybe_unused]] std::vector<RamDomain>& ret);
+private:
+SymbolTable& symTable;
+RecordTable& recordTable;
+ConcurrentCache<std::string,std::regex>& regexCache;
+bool& pruneImdtRels;
+bool& performIO;
+SignalHandler*& signalHandler;
+std::atomic<std::size_t>& iter;
+std::atomic<RamDomain>& ctr;
+std::string& inputDirectory;
+std::string& outputDirectory;
+t_btree_i__0__1::Type* rel_MaybeDeadlockingThread_bdb2bd10c95b5982;
+};
+} // namespace  souffle
+namespace  souffle {
+using namespace souffle;
+ Stratum_MaybeDeadlockingThread_fd0c8181097ea422::Stratum_MaybeDeadlockingThread_fd0c8181097ea422(SymbolTable& symTable,RecordTable& recordTable,ConcurrentCache<std::string,std::regex>& regexCache,bool& pruneImdtRels,bool& performIO,SignalHandler*& signalHandler,std::atomic<std::size_t>& iter,std::atomic<RamDomain>& ctr,std::string& inputDirectory,std::string& outputDirectory,t_btree_i__0__1::Type& rel_MaybeDeadlockingThread_bdb2bd10c95b5982):
+symTable(symTable),
+recordTable(recordTable),
+regexCache(regexCache),
+pruneImdtRels(pruneImdtRels),
+performIO(performIO),
+signalHandler(signalHandler),
+iter(iter),
+ctr(ctr),
+inputDirectory(inputDirectory),
+outputDirectory(outputDirectory),
+rel_MaybeDeadlockingThread_bdb2bd10c95b5982(&rel_MaybeDeadlockingThread_bdb2bd10c95b5982){
+}
+
+void Stratum_MaybeDeadlockingThread_fd0c8181097ea422::run([[maybe_unused]] const std::vector<RamDomain>& args,[[maybe_unused]] std::vector<RamDomain>& ret){
+if (performIO) {
+try {std::map<std::string, std::string> directiveMap({{"IO","file"},{"attributeNames","threadId"},{"auxArity","0"},{"fact-dir","."},{"name","MaybeDeadlockingThread"},{"operation","input"},{"params","{\"records\": {}, \"relation\": {\"arity\": 1, \"params\": [\"threadId\"]}}"},{"types","{\"ADTs\": {}, \"records\": {}, \"relation\": {\"arity\": 1, \"types\": [\"s:symbol\"]}}"}});
+if (!inputDirectory.empty()) {directiveMap["fact-dir"] = inputDirectory;}
+IOSystem::getInstance().getReader(directiveMap, symTable, recordTable)->readAll(*rel_MaybeDeadlockingThread_bdb2bd10c95b5982);
+} catch (std::exception& e) {std::cerr << "Error loading MaybeDeadlockingThread data: " << e.what() << '\n';
+exit(1);
+}
+}
+}
+
+} // namespace  souffle
+
+namespace  souffle {
+using namespace souffle;
+class Stratum_Reference_374a4e7377ff135c {
+public:
+ Stratum_Reference_374a4e7377ff135c(SymbolTable& symTable,RecordTable& recordTable,ConcurrentCache<std::string,std::regex>& regexCache,bool& pruneImdtRels,bool& performIO,SignalHandler*& signalHandler,std::atomic<std::size_t>& iter,std::atomic<RamDomain>& ctr,std::string& inputDirectory,std::string& outputDirectory,t_btree_ii__0_1__11__10::Type& rel_Reference_c57e388e43703de5);
+void run([[maybe_unused]] const std::vector<RamDomain>& args,[[maybe_unused]] std::vector<RamDomain>& ret);
+private:
+SymbolTable& symTable;
+RecordTable& recordTable;
+ConcurrentCache<std::string,std::regex>& regexCache;
+bool& pruneImdtRels;
+bool& performIO;
+SignalHandler*& signalHandler;
+std::atomic<std::size_t>& iter;
+std::atomic<RamDomain>& ctr;
+std::string& inputDirectory;
+std::string& outputDirectory;
+t_btree_ii__0_1__11__10::Type* rel_Reference_c57e388e43703de5;
+};
+} // namespace  souffle
+namespace  souffle {
+using namespace souffle;
+ Stratum_Reference_374a4e7377ff135c::Stratum_Reference_374a4e7377ff135c(SymbolTable& symTable,RecordTable& recordTable,ConcurrentCache<std::string,std::regex>& regexCache,bool& pruneImdtRels,bool& performIO,SignalHandler*& signalHandler,std::atomic<std::size_t>& iter,std::atomic<RamDomain>& ctr,std::string& inputDirectory,std::string& outputDirectory,t_btree_ii__0_1__11__10::Type& rel_Reference_c57e388e43703de5):
+symTable(symTable),
+recordTable(recordTable),
+regexCache(regexCache),
+pruneImdtRels(pruneImdtRels),
+performIO(performIO),
+signalHandler(signalHandler),
+iter(iter),
+ctr(ctr),
+inputDirectory(inputDirectory),
+outputDirectory(outputDirectory),
+rel_Reference_c57e388e43703de5(&rel_Reference_c57e388e43703de5){
+}
+
+void Stratum_Reference_374a4e7377ff135c::run([[maybe_unused]] const std::vector<RamDomain>& args,[[maybe_unused]] std::vector<RamDomain>& ret){
+if (performIO) {
+try {std::map<std::string, std::string> directiveMap({{"IO","file"},{"attributeNames","from\tto"},{"auxArity","0"},{"fact-dir","."},{"name","Reference"},{"operation","input"},{"params","{\"records\": {}, \"relation\": {\"arity\": 2, \"params\": [\"from\", \"to\"]}}"},{"types","{\"ADTs\": {}, \"records\": {}, \"relation\": {\"arity\": 2, \"types\": [\"s:symbol\", \"s:symbol\"]}}"}});
+if (!inputDirectory.empty()) {directiveMap["fact-dir"] = inputDirectory;}
+IOSystem::getInstance().getReader(directiveMap, symTable, recordTable)->readAll(*rel_Reference_c57e388e43703de5);
+} catch (std::exception& e) {std::cerr << "Error loading Reference data: " << e.what() << '\n';
+exit(1);
+}
+}
+}
+
+} // namespace  souffle
+
+namespace  souffle {
+using namespace souffle;
+class Sf_ext_stg_gc: public SouffleProgram {
+public:
+ Sf_ext_stg_gc();
+ ~Sf_ext_stg_gc();
+void run();
+void runAll(std::string inputDirectoryArg = "",std::string outputDirectoryArg = "",bool performIOArg = true,bool pruneImdtRelsArg = true);
+void printAll([[maybe_unused]] std::string outputDirectoryArg = "");
+void loadAll([[maybe_unused]] std::string inputDirectoryArg = "");
+void dumpInputs();
+void dumpOutputs();
+SymbolTable& getSymbolTable();
+RecordTable& getRecordTable();
+void setNumThreads(std::size_t numThreadsValue);
+void executeSubroutine(std::string name,const std::vector<RamDomain>& args,std::vector<RamDomain>& ret);
+private:
+void runFunction(std::string inputDirectoryArg,std::string outputDirectoryArg,bool performIOArg,bool pruneImdtRelsArg);
+SymbolTableImpl symTable;
+SpecializedRecordTable<0> recordTable;
+ConcurrentCache<std::string,std::regex> regexCache;
+Own<t_btree_i__0__1::Type> rel_GCRoot_f9754bdf5b76c5df;
+souffle::RelationWrapper<t_btree_i__0__1::Type> wrapper_rel_GCRoot_f9754bdf5b76c5df;
+Own<t_btree_ii__0_1__11__10::Type> rel_Reference_c57e388e43703de5;
+souffle::RelationWrapper<t_btree_ii__0_1__11__10::Type> wrapper_rel_Reference_c57e388e43703de5;
+Own<t_btree_i__0__1::Type> rel_LiveStep0_d54eeb7faabc4a13;
+souffle::RelationWrapper<t_btree_i__0__1::Type> wrapper_rel_LiveStep0_d54eeb7faabc4a13;
+Own<t_btree_i__0__1::Type> rel_delta_LiveStep0_749758939b4491e5;
+Own<t_btree_i__0__1::Type> rel_new_LiveStep0_b9970262b9a948e9;
+Own<t_btree_i__0__1::Type> rel_MaybeDeadlockingThread_bdb2bd10c95b5982;
+souffle::RelationWrapper<t_btree_i__0__1::Type> wrapper_rel_MaybeDeadlockingThread_bdb2bd10c95b5982;
+Own<t_btree_i__0__1::Type> rel_DeadlockingThread_8fa18e0d3ee84b8b;
+souffle::RelationWrapper<t_btree_i__0__1::Type> wrapper_rel_DeadlockingThread_8fa18e0d3ee84b8b;
+Own<t_btree_i__0__1::Type> rel_Live_2818460375647c67;
+souffle::RelationWrapper<t_btree_i__0__1::Type> wrapper_rel_Live_2818460375647c67;
+Own<t_btree_i__0__1::Type> rel_delta_Live_2c57e9662e50a2a0;
+Own<t_btree_i__0__1::Type> rel_new_Live_ca472dbac4201e48;
+Stratum_DeadlockingThread_69894afebfc94aee stratum_DeadlockingThread_18d51e522370d17d;
+Stratum_GCRoot_b08a674c48c5fe0e stratum_GCRoot_491c769852c0cbee;
+Stratum_Live_b9069971975f423e stratum_Live_20b0d7b68b7a9f85;
+Stratum_LiveStep0_41822abe1018780c stratum_LiveStep0_27a7e024cece5ac3;
+Stratum_MaybeDeadlockingThread_fd0c8181097ea422 stratum_MaybeDeadlockingThread_83fe8fd8c29c2f3b;
+Stratum_Reference_374a4e7377ff135c stratum_Reference_abb7727ac43549af;
+std::string inputDirectory;
+std::string outputDirectory;
+SignalHandler* signalHandler{SignalHandler::instance()};
+std::atomic<RamDomain> ctr{};
+std::atomic<std::size_t> iter{};
+};
+} // namespace  souffle
+namespace  souffle {
+using namespace souffle;
+ Sf_ext_stg_gc::Sf_ext_stg_gc():
+symTable(),
+recordTable(),
+regexCache(),
+rel_GCRoot_f9754bdf5b76c5df(mk<t_btree_i__0__1::Type>()),
+wrapper_rel_GCRoot_f9754bdf5b76c5df(0, *rel_GCRoot_f9754bdf5b76c5df, *this, "GCRoot", std::array<const char *,1>{{"s:symbol"}}, std::array<const char *,1>{{"val"}}, 0),
+rel_Reference_c57e388e43703de5(mk<t_btree_ii__0_1__11__10::Type>()),
+wrapper_rel_Reference_c57e388e43703de5(1, *rel_Reference_c57e388e43703de5, *this, "Reference", std::array<const char *,2>{{"s:symbol","s:symbol"}}, std::array<const char *,2>{{"from","to"}}, 0),
+rel_LiveStep0_d54eeb7faabc4a13(mk<t_btree_i__0__1::Type>()),
+wrapper_rel_LiveStep0_d54eeb7faabc4a13(2, *rel_LiveStep0_d54eeb7faabc4a13, *this, "LiveStep0", std::array<const char *,1>{{"s:symbol"}}, std::array<const char *,1>{{"val"}}, 0),
+rel_delta_LiveStep0_749758939b4491e5(mk<t_btree_i__0__1::Type>()),
+rel_new_LiveStep0_b9970262b9a948e9(mk<t_btree_i__0__1::Type>()),
+rel_MaybeDeadlockingThread_bdb2bd10c95b5982(mk<t_btree_i__0__1::Type>()),
+wrapper_rel_MaybeDeadlockingThread_bdb2bd10c95b5982(3, *rel_MaybeDeadlockingThread_bdb2bd10c95b5982, *this, "MaybeDeadlockingThread", std::array<const char *,1>{{"s:symbol"}}, std::array<const char *,1>{{"threadId"}}, 0),
+rel_DeadlockingThread_8fa18e0d3ee84b8b(mk<t_btree_i__0__1::Type>()),
+wrapper_rel_DeadlockingThread_8fa18e0d3ee84b8b(4, *rel_DeadlockingThread_8fa18e0d3ee84b8b, *this, "DeadlockingThread", std::array<const char *,1>{{"s:symbol"}}, std::array<const char *,1>{{"threadId"}}, 0),
+rel_Live_2818460375647c67(mk<t_btree_i__0__1::Type>()),
+wrapper_rel_Live_2818460375647c67(5, *rel_Live_2818460375647c67, *this, "Live", std::array<const char *,1>{{"s:symbol"}}, std::array<const char *,1>{{"val"}}, 0),
+rel_delta_Live_2c57e9662e50a2a0(mk<t_btree_i__0__1::Type>()),
+rel_new_Live_ca472dbac4201e48(mk<t_btree_i__0__1::Type>()),
+stratum_DeadlockingThread_18d51e522370d17d(symTable,recordTable,regexCache,pruneImdtRels,performIO,signalHandler,iter,ctr,inputDirectory,outputDirectory,*rel_DeadlockingThread_8fa18e0d3ee84b8b,*rel_LiveStep0_d54eeb7faabc4a13,*rel_MaybeDeadlockingThread_bdb2bd10c95b5982),
+stratum_GCRoot_491c769852c0cbee(symTable,recordTable,regexCache,pruneImdtRels,performIO,signalHandler,iter,ctr,inputDirectory,outputDirectory,*rel_GCRoot_f9754bdf5b76c5df),
+stratum_Live_20b0d7b68b7a9f85(symTable,recordTable,regexCache,pruneImdtRels,performIO,signalHandler,iter,ctr,inputDirectory,outputDirectory,*rel_delta_Live_2c57e9662e50a2a0,*rel_new_Live_ca472dbac4201e48,*rel_DeadlockingThread_8fa18e0d3ee84b8b,*rel_Live_2818460375647c67,*rel_LiveStep0_d54eeb7faabc4a13,*rel_Reference_c57e388e43703de5),
+stratum_LiveStep0_27a7e024cece5ac3(symTable,recordTable,regexCache,pruneImdtRels,performIO,signalHandler,iter,ctr,inputDirectory,outputDirectory,*rel_delta_LiveStep0_749758939b4491e5,*rel_new_LiveStep0_b9970262b9a948e9,*rel_GCRoot_f9754bdf5b76c5df,*rel_LiveStep0_d54eeb7faabc4a13,*rel_Reference_c57e388e43703de5),
+stratum_MaybeDeadlockingThread_83fe8fd8c29c2f3b(symTable,recordTable,regexCache,pruneImdtRels,performIO,signalHandler,iter,ctr,inputDirectory,outputDirectory,*rel_MaybeDeadlockingThread_bdb2bd10c95b5982),
+stratum_Reference_abb7727ac43549af(symTable,recordTable,regexCache,pruneImdtRels,performIO,signalHandler,iter,ctr,inputDirectory,outputDirectory,*rel_Reference_c57e388e43703de5){
+addRelation("GCRoot", wrapper_rel_GCRoot_f9754bdf5b76c5df, true, false);
+addRelation("Reference", wrapper_rel_Reference_c57e388e43703de5, true, false);
+addRelation("LiveStep0", wrapper_rel_LiveStep0_d54eeb7faabc4a13, false, false);
+addRelation("MaybeDeadlockingThread", wrapper_rel_MaybeDeadlockingThread_bdb2bd10c95b5982, true, false);
+addRelation("DeadlockingThread", wrapper_rel_DeadlockingThread_8fa18e0d3ee84b8b, false, true);
+addRelation("Live", wrapper_rel_Live_2818460375647c67, false, true);
+}
+
+ Sf_ext_stg_gc::~Sf_ext_stg_gc(){
+}
+
+void Sf_ext_stg_gc::runFunction(std::string inputDirectoryArg,std::string outputDirectoryArg,bool performIOArg,bool pruneImdtRelsArg){
+
     this->inputDirectory  = std::move(inputDirectoryArg);
     this->outputDirectory = std::move(outputDirectoryArg);
     this->performIO       = performIOArg;
-    this->pruneImdtRels   = pruneImdtRelsArg; 
+    this->pruneImdtRels   = pruneImdtRelsArg;
 
     // set default threads (in embedded mode)
     // if this is not set, and omp is used, the default omp setting of number of cores is used.
@@ -311,429 +900,154 @@ void runFunction(std::string  inputDirectoryArg,
 // -- query evaluation --
 {
  std::vector<RamDomain> args, ret;
-subroutine_0(args, ret);
+stratum_GCRoot_491c769852c0cbee.run(args, ret);
 }
 {
  std::vector<RamDomain> args, ret;
-subroutine_1(args, ret);
+stratum_Reference_abb7727ac43549af.run(args, ret);
 }
 {
  std::vector<RamDomain> args, ret;
-subroutine_2(args, ret);
+stratum_LiveStep0_27a7e024cece5ac3.run(args, ret);
 }
 {
  std::vector<RamDomain> args, ret;
-subroutine_3(args, ret);
+stratum_MaybeDeadlockingThread_83fe8fd8c29c2f3b.run(args, ret);
 }
 {
  std::vector<RamDomain> args, ret;
-subroutine_4(args, ret);
+stratum_DeadlockingThread_18d51e522370d17d.run(args, ret);
 }
 {
  std::vector<RamDomain> args, ret;
-subroutine_5(args, ret);
+stratum_Live_20b0d7b68b7a9f85.run(args, ret);
 }
 
 // -- relation hint statistics --
 signalHandler->reset();
 }
-public:
-void run() override { runFunction("", "", false, false); }
-public:
-void runAll(std::string inputDirectoryArg = "", std::string outputDirectoryArg = "", bool performIOArg=true, bool pruneImdtRelsArg=true) override { runFunction(inputDirectoryArg, outputDirectoryArg, performIOArg, pruneImdtRelsArg);
+
+void Sf_ext_stg_gc::run(){
+runFunction("", "", false, false);
 }
-public:
-void printAll(std::string outputDirectoryArg = "") override {
+
+void Sf_ext_stg_gc::runAll(std::string inputDirectoryArg,std::string outputDirectoryArg,bool performIOArg,bool pruneImdtRelsArg){
+runFunction(inputDirectoryArg, outputDirectoryArg, performIOArg, pruneImdtRelsArg);
+}
+
+void Sf_ext_stg_gc::printAll([[maybe_unused]] std::string outputDirectoryArg){
 try {std::map<std::string, std::string> directiveMap({{"IO","file"},{"attributeNames","threadId"},{"auxArity","0"},{"name","DeadlockingThread"},{"operation","output"},{"output-dir","."},{"params","{\"records\": {}, \"relation\": {\"arity\": 1, \"params\": [\"threadId\"]}}"},{"types","{\"ADTs\": {}, \"records\": {}, \"relation\": {\"arity\": 1, \"types\": [\"s:symbol\"]}}"}});
 if (!outputDirectoryArg.empty()) {directiveMap["output-dir"] = outputDirectoryArg;}
-IOSystem::getInstance().getWriter(directiveMap, symTable, recordTable)->writeAll(*rel_7_DeadlockingThread);
+IOSystem::getInstance().getWriter(directiveMap, symTable, recordTable)->writeAll(*rel_DeadlockingThread_8fa18e0d3ee84b8b);
 } catch (std::exception& e) {std::cerr << e.what();exit(1);}
 try {std::map<std::string, std::string> directiveMap({{"IO","file"},{"attributeNames","val"},{"auxArity","0"},{"name","Live"},{"operation","output"},{"output-dir","."},{"params","{\"records\": {}, \"relation\": {\"arity\": 1, \"params\": [\"val\"]}}"},{"types","{\"ADTs\": {}, \"records\": {}, \"relation\": {\"arity\": 1, \"types\": [\"s:symbol\"]}}"}});
 if (!outputDirectoryArg.empty()) {directiveMap["output-dir"] = outputDirectoryArg;}
-IOSystem::getInstance().getWriter(directiveMap, symTable, recordTable)->writeAll(*rel_8_Live);
+IOSystem::getInstance().getWriter(directiveMap, symTable, recordTable)->writeAll(*rel_Live_2818460375647c67);
 } catch (std::exception& e) {std::cerr << e.what();exit(1);}
 }
-public:
-void loadAll(std::string inputDirectoryArg = "") override {
+
+void Sf_ext_stg_gc::loadAll([[maybe_unused]] std::string inputDirectoryArg){
 try {std::map<std::string, std::string> directiveMap({{"IO","file"},{"attributeNames","val"},{"auxArity","0"},{"fact-dir","."},{"name","GCRoot"},{"operation","input"},{"params","{\"records\": {}, \"relation\": {\"arity\": 1, \"params\": [\"val\"]}}"},{"types","{\"ADTs\": {}, \"records\": {}, \"relation\": {\"arity\": 1, \"types\": [\"s:symbol\"]}}"}});
 if (!inputDirectoryArg.empty()) {directiveMap["fact-dir"] = inputDirectoryArg;}
-IOSystem::getInstance().getReader(directiveMap, symTable, recordTable)->readAll(*rel_1_GCRoot);
-} catch (std::exception& e) {std::cerr << "Error loading GCRoot data: " << e.what() << '\n';}
-try {std::map<std::string, std::string> directiveMap({{"IO","file"},{"attributeNames","threadId"},{"auxArity","0"},{"fact-dir","."},{"name","MaybeDeadlockingThread"},{"operation","input"},{"params","{\"records\": {}, \"relation\": {\"arity\": 1, \"params\": [\"threadId\"]}}"},{"types","{\"ADTs\": {}, \"records\": {}, \"relation\": {\"arity\": 1, \"types\": [\"s:symbol\"]}}"}});
-if (!inputDirectoryArg.empty()) {directiveMap["fact-dir"] = inputDirectoryArg;}
-IOSystem::getInstance().getReader(directiveMap, symTable, recordTable)->readAll(*rel_6_MaybeDeadlockingThread);
-} catch (std::exception& e) {std::cerr << "Error loading MaybeDeadlockingThread data: " << e.what() << '\n';}
+IOSystem::getInstance().getReader(directiveMap, symTable, recordTable)->readAll(*rel_GCRoot_f9754bdf5b76c5df);
+} catch (std::exception& e) {std::cerr << "Error loading GCRoot data: " << e.what() << '\n';
+exit(1);
+}
 try {std::map<std::string, std::string> directiveMap({{"IO","file"},{"attributeNames","from\tto"},{"auxArity","0"},{"fact-dir","."},{"name","Reference"},{"operation","input"},{"params","{\"records\": {}, \"relation\": {\"arity\": 2, \"params\": [\"from\", \"to\"]}}"},{"types","{\"ADTs\": {}, \"records\": {}, \"relation\": {\"arity\": 2, \"types\": [\"s:symbol\", \"s:symbol\"]}}"}});
 if (!inputDirectoryArg.empty()) {directiveMap["fact-dir"] = inputDirectoryArg;}
-IOSystem::getInstance().getReader(directiveMap, symTable, recordTable)->readAll(*rel_2_Reference);
-} catch (std::exception& e) {std::cerr << "Error loading Reference data: " << e.what() << '\n';}
+IOSystem::getInstance().getReader(directiveMap, symTable, recordTable)->readAll(*rel_Reference_c57e388e43703de5);
+} catch (std::exception& e) {std::cerr << "Error loading Reference data: " << e.what() << '\n';
+exit(1);
 }
-public:
-void dumpInputs() override {
+try {std::map<std::string, std::string> directiveMap({{"IO","file"},{"attributeNames","threadId"},{"auxArity","0"},{"fact-dir","."},{"name","MaybeDeadlockingThread"},{"operation","input"},{"params","{\"records\": {}, \"relation\": {\"arity\": 1, \"params\": [\"threadId\"]}}"},{"types","{\"ADTs\": {}, \"records\": {}, \"relation\": {\"arity\": 1, \"types\": [\"s:symbol\"]}}"}});
+if (!inputDirectoryArg.empty()) {directiveMap["fact-dir"] = inputDirectoryArg;}
+IOSystem::getInstance().getReader(directiveMap, symTable, recordTable)->readAll(*rel_MaybeDeadlockingThread_bdb2bd10c95b5982);
+} catch (std::exception& e) {std::cerr << "Error loading MaybeDeadlockingThread data: " << e.what() << '\n';
+exit(1);
+}
+}
+
+void Sf_ext_stg_gc::dumpInputs(){
 try {std::map<std::string, std::string> rwOperation;
 rwOperation["IO"] = "stdout";
 rwOperation["name"] = "GCRoot";
 rwOperation["types"] = "{\"relation\": {\"arity\": 1, \"auxArity\": 0, \"types\": [\"s:symbol\"]}}";
-IOSystem::getInstance().getWriter(rwOperation, symTable, recordTable)->writeAll(*rel_1_GCRoot);
-} catch (std::exception& e) {std::cerr << e.what();exit(1);}
-try {std::map<std::string, std::string> rwOperation;
-rwOperation["IO"] = "stdout";
-rwOperation["name"] = "MaybeDeadlockingThread";
-rwOperation["types"] = "{\"relation\": {\"arity\": 1, \"auxArity\": 0, \"types\": [\"s:symbol\"]}}";
-IOSystem::getInstance().getWriter(rwOperation, symTable, recordTable)->writeAll(*rel_6_MaybeDeadlockingThread);
+IOSystem::getInstance().getWriter(rwOperation, symTable, recordTable)->writeAll(*rel_GCRoot_f9754bdf5b76c5df);
 } catch (std::exception& e) {std::cerr << e.what();exit(1);}
 try {std::map<std::string, std::string> rwOperation;
 rwOperation["IO"] = "stdout";
 rwOperation["name"] = "Reference";
 rwOperation["types"] = "{\"relation\": {\"arity\": 2, \"auxArity\": 0, \"types\": [\"s:symbol\", \"s:symbol\"]}}";
-IOSystem::getInstance().getWriter(rwOperation, symTable, recordTable)->writeAll(*rel_2_Reference);
+IOSystem::getInstance().getWriter(rwOperation, symTable, recordTable)->writeAll(*rel_Reference_c57e388e43703de5);
+} catch (std::exception& e) {std::cerr << e.what();exit(1);}
+try {std::map<std::string, std::string> rwOperation;
+rwOperation["IO"] = "stdout";
+rwOperation["name"] = "MaybeDeadlockingThread";
+rwOperation["types"] = "{\"relation\": {\"arity\": 1, \"auxArity\": 0, \"types\": [\"s:symbol\"]}}";
+IOSystem::getInstance().getWriter(rwOperation, symTable, recordTable)->writeAll(*rel_MaybeDeadlockingThread_bdb2bd10c95b5982);
 } catch (std::exception& e) {std::cerr << e.what();exit(1);}
 }
-public:
-void dumpOutputs() override {
+
+void Sf_ext_stg_gc::dumpOutputs(){
 try {std::map<std::string, std::string> rwOperation;
 rwOperation["IO"] = "stdout";
 rwOperation["name"] = "DeadlockingThread";
 rwOperation["types"] = "{\"relation\": {\"arity\": 1, \"auxArity\": 0, \"types\": [\"s:symbol\"]}}";
-IOSystem::getInstance().getWriter(rwOperation, symTable, recordTable)->writeAll(*rel_7_DeadlockingThread);
+IOSystem::getInstance().getWriter(rwOperation, symTable, recordTable)->writeAll(*rel_DeadlockingThread_8fa18e0d3ee84b8b);
 } catch (std::exception& e) {std::cerr << e.what();exit(1);}
 try {std::map<std::string, std::string> rwOperation;
 rwOperation["IO"] = "stdout";
 rwOperation["name"] = "Live";
 rwOperation["types"] = "{\"relation\": {\"arity\": 1, \"auxArity\": 0, \"types\": [\"s:symbol\"]}}";
-IOSystem::getInstance().getWriter(rwOperation, symTable, recordTable)->writeAll(*rel_8_Live);
+IOSystem::getInstance().getWriter(rwOperation, symTable, recordTable)->writeAll(*rel_Live_2818460375647c67);
 } catch (std::exception& e) {std::cerr << e.what();exit(1);}
 }
-public:
-SymbolTable& getSymbolTable() override {
+
+SymbolTable& Sf_ext_stg_gc::getSymbolTable(){
 return symTable;
 }
-RecordTable& getRecordTable() override {
+
+RecordTable& Sf_ext_stg_gc::getRecordTable(){
 return recordTable;
 }
-void setNumThreads(std::size_t numThreadsValue) override {
+
+void Sf_ext_stg_gc::setNumThreads(std::size_t numThreadsValue){
 SouffleProgram::setNumThreads(numThreadsValue);
 symTable.setNumLanes(getNumThreads());
 recordTable.setNumLanes(getNumThreads());
+regexCache.setNumLanes(getNumThreads());
 }
-void executeSubroutine(std::string name, const std::vector<RamDomain>& args, std::vector<RamDomain>& ret) override {
-if (name == "stratum_0") {
-subroutine_0(args, ret);
-return;}
-if (name == "stratum_1") {
-subroutine_1(args, ret);
-return;}
-if (name == "stratum_2") {
-subroutine_2(args, ret);
-return;}
-if (name == "stratum_3") {
-subroutine_3(args, ret);
-return;}
-if (name == "stratum_4") {
-subroutine_4(args, ret);
-return;}
-if (name == "stratum_5") {
-subroutine_5(args, ret);
-return;}
-fatal("unknown subroutine");
-}
-#ifdef _MSC_VER
-#pragma warning(disable: 4100)
-#endif // _MSC_VER
-void subroutine_0(const std::vector<RamDomain>& args, std::vector<RamDomain>& ret) {
-if (performIO) {
-try {std::map<std::string, std::string> directiveMap({{"IO","file"},{"attributeNames","val"},{"auxArity","0"},{"fact-dir","."},{"name","GCRoot"},{"operation","input"},{"params","{\"records\": {}, \"relation\": {\"arity\": 1, \"params\": [\"val\"]}}"},{"types","{\"ADTs\": {}, \"records\": {}, \"relation\": {\"arity\": 1, \"types\": [\"s:symbol\"]}}"}});
-if (!inputDirectory.empty()) {directiveMap["fact-dir"] = inputDirectory;}
-IOSystem::getInstance().getReader(directiveMap, symTable, recordTable)->readAll(*rel_1_GCRoot);
-} catch (std::exception& e) {std::cerr << "Error loading GCRoot data: " << e.what() << '\n';}
-}
-}
-#ifdef _MSC_VER
-#pragma warning(default: 4100)
-#endif // _MSC_VER
-#ifdef _MSC_VER
-#pragma warning(disable: 4100)
-#endif // _MSC_VER
-void subroutine_1(const std::vector<RamDomain>& args, std::vector<RamDomain>& ret) {
-if (performIO) {
-try {std::map<std::string, std::string> directiveMap({{"IO","file"},{"attributeNames","from\tto"},{"auxArity","0"},{"fact-dir","."},{"name","Reference"},{"operation","input"},{"params","{\"records\": {}, \"relation\": {\"arity\": 2, \"params\": [\"from\", \"to\"]}}"},{"types","{\"ADTs\": {}, \"records\": {}, \"relation\": {\"arity\": 2, \"types\": [\"s:symbol\", \"s:symbol\"]}}"}});
-if (!inputDirectory.empty()) {directiveMap["fact-dir"] = inputDirectory;}
-IOSystem::getInstance().getReader(directiveMap, symTable, recordTable)->readAll(*rel_2_Reference);
-} catch (std::exception& e) {std::cerr << "Error loading Reference data: " << e.what() << '\n';}
-}
-}
-#ifdef _MSC_VER
-#pragma warning(default: 4100)
-#endif // _MSC_VER
-#ifdef _MSC_VER
-#pragma warning(disable: 4100)
-#endif // _MSC_VER
-void subroutine_2(const std::vector<RamDomain>& args, std::vector<RamDomain>& ret) {
-signalHandler->setMsg(R"_(LiveStep0(ref) :- 
-   GCRoot(ref).
-in file ext-stg-gc.dl [26:1-26:31])_");
-if(!(rel_1_GCRoot->empty())) {
-[&](){
-CREATE_OP_CONTEXT(rel_3_LiveStep0_op_ctxt,rel_3_LiveStep0->createContext());
-CREATE_OP_CONTEXT(rel_1_GCRoot_op_ctxt,rel_1_GCRoot->createContext());
-for(const auto& env0 : *rel_1_GCRoot) {
-Tuple<RamDomain,1> tuple{{ramBitCast(env0[0])}};
-rel_3_LiveStep0->insert(tuple,READ_OP_CONTEXT(rel_3_LiveStep0_op_ctxt));
-}
-}
-();}
-[&](){
-CREATE_OP_CONTEXT(rel_3_LiveStep0_op_ctxt,rel_3_LiveStep0->createContext());
-CREATE_OP_CONTEXT(rel_4_delta_LiveStep0_op_ctxt,rel_4_delta_LiveStep0->createContext());
-for(const auto& env0 : *rel_3_LiveStep0) {
-Tuple<RamDomain,1> tuple{{ramBitCast(env0[0])}};
-rel_4_delta_LiveStep0->insert(tuple,READ_OP_CONTEXT(rel_4_delta_LiveStep0_op_ctxt));
-}
-}
-();iter = 0;
-for(;;) {
-signalHandler->setMsg(R"_(LiveStep0(to) :- 
-   LiveStep0(from),
-   Reference(from,to).
-in file ext-stg-gc.dl [28:1-30:23])_");
-if(!(rel_4_delta_LiveStep0->empty()) && !(rel_2_Reference->empty())) {
-[&](){
-auto part = rel_4_delta_LiveStep0->partition();
-PARALLEL_START
-CREATE_OP_CONTEXT(rel_3_LiveStep0_op_ctxt,rel_3_LiveStep0->createContext());
-CREATE_OP_CONTEXT(rel_4_delta_LiveStep0_op_ctxt,rel_4_delta_LiveStep0->createContext());
-CREATE_OP_CONTEXT(rel_5_new_LiveStep0_op_ctxt,rel_5_new_LiveStep0->createContext());
-CREATE_OP_CONTEXT(rel_2_Reference_op_ctxt,rel_2_Reference->createContext());
 
-                   #if defined _OPENMP && _OPENMP < 200805
-                           auto count = std::distance(part.begin(), part.end());
-                           auto base = part.begin();
-                           pfor(int index  = 0; index < count; index++) {
-                               auto it = base + index;
-                   #else
-                           pfor(auto it = part.begin(); it < part.end(); it++) {
-                   #endif
-                   try{
-for(const auto& env0 : *it) {
-auto range = rel_2_Reference->lowerUpperRange_10(Tuple<RamDomain,2>{{ramBitCast(env0[0]), ramBitCast<RamDomain>(MIN_RAM_SIGNED)}},Tuple<RamDomain,2>{{ramBitCast(env0[0]), ramBitCast<RamDomain>(MAX_RAM_SIGNED)}},READ_OP_CONTEXT(rel_2_Reference_op_ctxt));
-for(const auto& env1 : range) {
-if( !(rel_3_LiveStep0->contains(Tuple<RamDomain,1>{{ramBitCast(env1[1])}},READ_OP_CONTEXT(rel_3_LiveStep0_op_ctxt)))) {
-Tuple<RamDomain,1> tuple{{ramBitCast(env1[1])}};
-rel_5_new_LiveStep0->insert(tuple,READ_OP_CONTEXT(rel_5_new_LiveStep0_op_ctxt));
+void Sf_ext_stg_gc::executeSubroutine(std::string name,const std::vector<RamDomain>& args,std::vector<RamDomain>& ret){
+if (name == "DeadlockingThread") {
+stratum_DeadlockingThread_18d51e522370d17d.run(args, ret);
+return;}
+if (name == "GCRoot") {
+stratum_GCRoot_491c769852c0cbee.run(args, ret);
+return;}
+if (name == "Live") {
+stratum_Live_20b0d7b68b7a9f85.run(args, ret);
+return;}
+if (name == "LiveStep0") {
+stratum_LiveStep0_27a7e024cece5ac3.run(args, ret);
+return;}
+if (name == "MaybeDeadlockingThread") {
+stratum_MaybeDeadlockingThread_83fe8fd8c29c2f3b.run(args, ret);
+return;}
+if (name == "Reference") {
+stratum_Reference_abb7727ac43549af.run(args, ret);
+return;}
+fatal(("unknown subroutine " + name).c_str());
 }
-}
-}
-} catch(std::exception &e) { signalHandler->error(e.what());}
-}
-PARALLEL_END
-}
-();}
-if(rel_5_new_LiveStep0->empty()) break;
-[&](){
-CREATE_OP_CONTEXT(rel_3_LiveStep0_op_ctxt,rel_3_LiveStep0->createContext());
-CREATE_OP_CONTEXT(rel_5_new_LiveStep0_op_ctxt,rel_5_new_LiveStep0->createContext());
-for(const auto& env0 : *rel_5_new_LiveStep0) {
-Tuple<RamDomain,1> tuple{{ramBitCast(env0[0])}};
-rel_3_LiveStep0->insert(tuple,READ_OP_CONTEXT(rel_3_LiveStep0_op_ctxt));
-}
-}
-();std::swap(rel_4_delta_LiveStep0, rel_5_new_LiveStep0);
-rel_5_new_LiveStep0->purge();
-iter++;
-}
-iter = 0;
-rel_4_delta_LiveStep0->purge();
-rel_5_new_LiveStep0->purge();
-if (pruneImdtRels) rel_1_GCRoot->purge();
-}
-#ifdef _MSC_VER
-#pragma warning(default: 4100)
-#endif // _MSC_VER
-#ifdef _MSC_VER
-#pragma warning(disable: 4100)
-#endif // _MSC_VER
-void subroutine_3(const std::vector<RamDomain>& args, std::vector<RamDomain>& ret) {
-if (performIO) {
-try {std::map<std::string, std::string> directiveMap({{"IO","file"},{"attributeNames","threadId"},{"auxArity","0"},{"fact-dir","."},{"name","MaybeDeadlockingThread"},{"operation","input"},{"params","{\"records\": {}, \"relation\": {\"arity\": 1, \"params\": [\"threadId\"]}}"},{"types","{\"ADTs\": {}, \"records\": {}, \"relation\": {\"arity\": 1, \"types\": [\"s:symbol\"]}}"}});
-if (!inputDirectory.empty()) {directiveMap["fact-dir"] = inputDirectory;}
-IOSystem::getInstance().getReader(directiveMap, symTable, recordTable)->readAll(*rel_6_MaybeDeadlockingThread);
-} catch (std::exception& e) {std::cerr << "Error loading MaybeDeadlockingThread data: " << e.what() << '\n';}
-}
-}
-#ifdef _MSC_VER
-#pragma warning(default: 4100)
-#endif // _MSC_VER
-#ifdef _MSC_VER
-#pragma warning(disable: 4100)
-#endif // _MSC_VER
-void subroutine_4(const std::vector<RamDomain>& args, std::vector<RamDomain>& ret) {
-signalHandler->setMsg(R"_(DeadlockingThread(tid) :- 
-   MaybeDeadlockingThread(tid),
-   !LiveStep0(tid).
-in file ext-stg-gc.dl [41:1-43:19])_");
-if(!(rel_6_MaybeDeadlockingThread->empty())) {
-[&](){
-auto part = rel_6_MaybeDeadlockingThread->partition();
-PARALLEL_START
-CREATE_OP_CONTEXT(rel_3_LiveStep0_op_ctxt,rel_3_LiveStep0->createContext());
-CREATE_OP_CONTEXT(rel_6_MaybeDeadlockingThread_op_ctxt,rel_6_MaybeDeadlockingThread->createContext());
-CREATE_OP_CONTEXT(rel_7_DeadlockingThread_op_ctxt,rel_7_DeadlockingThread->createContext());
 
-                   #if defined _OPENMP && _OPENMP < 200805
-                           auto count = std::distance(part.begin(), part.end());
-                           auto base = part.begin();
-                           pfor(int index  = 0; index < count; index++) {
-                               auto it = base + index;
-                   #else
-                           pfor(auto it = part.begin(); it < part.end(); it++) {
-                   #endif
-                   try{
-for(const auto& env0 : *it) {
-if( !(rel_3_LiveStep0->contains(Tuple<RamDomain,1>{{ramBitCast(env0[0])}},READ_OP_CONTEXT(rel_3_LiveStep0_op_ctxt)))) {
-Tuple<RamDomain,1> tuple{{ramBitCast(env0[0])}};
-rel_7_DeadlockingThread->insert(tuple,READ_OP_CONTEXT(rel_7_DeadlockingThread_op_ctxt));
-}
-}
-} catch(std::exception &e) { signalHandler->error(e.what());}
-}
-PARALLEL_END
-}
-();}
-if (performIO) {
-try {std::map<std::string, std::string> directiveMap({{"IO","file"},{"attributeNames","threadId"},{"auxArity","0"},{"name","DeadlockingThread"},{"operation","output"},{"output-dir","."},{"params","{\"records\": {}, \"relation\": {\"arity\": 1, \"params\": [\"threadId\"]}}"},{"types","{\"ADTs\": {}, \"records\": {}, \"relation\": {\"arity\": 1, \"types\": [\"s:symbol\"]}}"}});
-if (!outputDirectory.empty()) {directiveMap["output-dir"] = outputDirectory;}
-IOSystem::getInstance().getWriter(directiveMap, symTable, recordTable)->writeAll(*rel_7_DeadlockingThread);
-} catch (std::exception& e) {std::cerr << e.what();exit(1);}
-}
-if (pruneImdtRels) rel_6_MaybeDeadlockingThread->purge();
-}
-#ifdef _MSC_VER
-#pragma warning(default: 4100)
-#endif // _MSC_VER
-#ifdef _MSC_VER
-#pragma warning(disable: 4100)
-#endif // _MSC_VER
-void subroutine_5(const std::vector<RamDomain>& args, std::vector<RamDomain>& ret) {
-signalHandler->setMsg(R"_(Live(tid) :- 
-   DeadlockingThread(tid).
-in file ext-stg-gc.dl [45:1-45:37])_");
-if(!(rel_7_DeadlockingThread->empty())) {
-[&](){
-CREATE_OP_CONTEXT(rel_7_DeadlockingThread_op_ctxt,rel_7_DeadlockingThread->createContext());
-CREATE_OP_CONTEXT(rel_8_Live_op_ctxt,rel_8_Live->createContext());
-for(const auto& env0 : *rel_7_DeadlockingThread) {
-Tuple<RamDomain,1> tuple{{ramBitCast(env0[0])}};
-rel_8_Live->insert(tuple,READ_OP_CONTEXT(rel_8_Live_op_ctxt));
-}
-}
-();}
-signalHandler->setMsg(R"_(Live(ref) :- 
-   LiveStep0(ref).
-in file ext-stg-gc.dl [46:1-46:29])_");
-if(!(rel_3_LiveStep0->empty())) {
-[&](){
-CREATE_OP_CONTEXT(rel_3_LiveStep0_op_ctxt,rel_3_LiveStep0->createContext());
-CREATE_OP_CONTEXT(rel_8_Live_op_ctxt,rel_8_Live->createContext());
-for(const auto& env0 : *rel_3_LiveStep0) {
-Tuple<RamDomain,1> tuple{{ramBitCast(env0[0])}};
-rel_8_Live->insert(tuple,READ_OP_CONTEXT(rel_8_Live_op_ctxt));
-}
-}
-();}
-[&](){
-CREATE_OP_CONTEXT(rel_8_Live_op_ctxt,rel_8_Live->createContext());
-CREATE_OP_CONTEXT(rel_9_delta_Live_op_ctxt,rel_9_delta_Live->createContext());
-for(const auto& env0 : *rel_8_Live) {
-Tuple<RamDomain,1> tuple{{ramBitCast(env0[0])}};
-rel_9_delta_Live->insert(tuple,READ_OP_CONTEXT(rel_9_delta_Live_op_ctxt));
-}
-}
-();iter = 0;
-for(;;) {
-signalHandler->setMsg(R"_(Live(to) :- 
-   Live(from),
-   Reference(from,to).
-in file ext-stg-gc.dl [47:1-49:23])_");
-if(!(rel_9_delta_Live->empty()) && !(rel_2_Reference->empty())) {
-[&](){
-auto part = rel_9_delta_Live->partition();
-PARALLEL_START
-CREATE_OP_CONTEXT(rel_2_Reference_op_ctxt,rel_2_Reference->createContext());
-CREATE_OP_CONTEXT(rel_8_Live_op_ctxt,rel_8_Live->createContext());
-CREATE_OP_CONTEXT(rel_9_delta_Live_op_ctxt,rel_9_delta_Live->createContext());
-CREATE_OP_CONTEXT(rel_10_new_Live_op_ctxt,rel_10_new_Live->createContext());
+} // namespace  souffle
+namespace souffle {
+SouffleProgram *newInstance_ext_stg_gc(){return new  souffle::Sf_ext_stg_gc;}
+SymbolTable *getST_ext_stg_gc(SouffleProgram *p){return &reinterpret_cast<souffle::Sf_ext_stg_gc*>(p)->getSymbolTable();}
+} // namespace souffle
 
-                   #if defined _OPENMP && _OPENMP < 200805
-                           auto count = std::distance(part.begin(), part.end());
-                           auto base = part.begin();
-                           pfor(int index  = 0; index < count; index++) {
-                               auto it = base + index;
-                   #else
-                           pfor(auto it = part.begin(); it < part.end(); it++) {
-                   #endif
-                   try{
-for(const auto& env0 : *it) {
-auto range = rel_2_Reference->lowerUpperRange_10(Tuple<RamDomain,2>{{ramBitCast(env0[0]), ramBitCast<RamDomain>(MIN_RAM_SIGNED)}},Tuple<RamDomain,2>{{ramBitCast(env0[0]), ramBitCast<RamDomain>(MAX_RAM_SIGNED)}},READ_OP_CONTEXT(rel_2_Reference_op_ctxt));
-for(const auto& env1 : range) {
-if( !(rel_8_Live->contains(Tuple<RamDomain,1>{{ramBitCast(env1[1])}},READ_OP_CONTEXT(rel_8_Live_op_ctxt)))) {
-Tuple<RamDomain,1> tuple{{ramBitCast(env1[1])}};
-rel_10_new_Live->insert(tuple,READ_OP_CONTEXT(rel_10_new_Live_op_ctxt));
-}
-}
-}
-} catch(std::exception &e) { signalHandler->error(e.what());}
-}
-PARALLEL_END
-}
-();}
-if(rel_10_new_Live->empty()) break;
-[&](){
-CREATE_OP_CONTEXT(rel_8_Live_op_ctxt,rel_8_Live->createContext());
-CREATE_OP_CONTEXT(rel_10_new_Live_op_ctxt,rel_10_new_Live->createContext());
-for(const auto& env0 : *rel_10_new_Live) {
-Tuple<RamDomain,1> tuple{{ramBitCast(env0[0])}};
-rel_8_Live->insert(tuple,READ_OP_CONTEXT(rel_8_Live_op_ctxt));
-}
-}
-();std::swap(rel_9_delta_Live, rel_10_new_Live);
-rel_10_new_Live->purge();
-iter++;
-}
-iter = 0;
-rel_9_delta_Live->purge();
-rel_10_new_Live->purge();
-if (performIO) {
-try {std::map<std::string, std::string> directiveMap({{"IO","file"},{"attributeNames","val"},{"auxArity","0"},{"name","Live"},{"operation","output"},{"output-dir","."},{"params","{\"records\": {}, \"relation\": {\"arity\": 1, \"params\": [\"val\"]}}"},{"types","{\"ADTs\": {}, \"records\": {}, \"relation\": {\"arity\": 1, \"types\": [\"s:symbol\"]}}"}});
-if (!outputDirectory.empty()) {directiveMap["output-dir"] = outputDirectory;}
-IOSystem::getInstance().getWriter(directiveMap, symTable, recordTable)->writeAll(*rel_8_Live);
-} catch (std::exception& e) {std::cerr << e.what();exit(1);}
-}
-if (pruneImdtRels) rel_8_Live->purge();
-if (pruneImdtRels) rel_3_LiveStep0->purge();
-if (pruneImdtRels) rel_2_Reference->purge();
-if (pruneImdtRels) rel_7_DeadlockingThread->purge();
-}
-#ifdef _MSC_VER
-#pragma warning(default: 4100)
-#endif // _MSC_VER
-};
-SouffleProgram *newInstance_ext_stg_gc(){return new Sf_ext_stg_gc;}
-SymbolTable *getST_ext_stg_gc(SouffleProgram *p){return &reinterpret_cast<Sf_ext_stg_gc*>(p)->getSymbolTable();}
-
-#ifdef __EMBEDDED_SOUFFLE__
-class factory_Sf_ext_stg_gc: public souffle::ProgramFactory {
-SouffleProgram *newInstance() {
-return new Sf_ext_stg_gc();
-};
-public:
-factory_Sf_ext_stg_gc() : ProgramFactory("ext_stg_gc"){}
-};
-extern "C" {
-factory_Sf_ext_stg_gc __factory_Sf_ext_stg_gc_instance;
-}
-}
-#else
-}
+#ifndef __EMBEDDED_SOUFFLE__
+#include "souffle/CompiledOptions.h"
 int main(int argc, char** argv)
 {
 try{
@@ -753,5 +1067,34 @@ obj.runAll(opt.getInputFileDir(), opt.getOutputFileDir());
 return 0;
 } catch(std::exception &e) { souffle::SignalHandler::instance()->error(e.what());}
 }
-
 #endif
+
+namespace  souffle {
+using namespace souffle;
+class factory_Sf_ext_stg_gc: souffle::ProgramFactory {
+public:
+souffle::SouffleProgram* newInstance();
+ factory_Sf_ext_stg_gc();
+private:
+};
+} // namespace  souffle
+namespace  souffle {
+using namespace souffle;
+souffle::SouffleProgram* factory_Sf_ext_stg_gc::newInstance(){
+return new  souffle::Sf_ext_stg_gc();
+}
+
+ factory_Sf_ext_stg_gc::factory_Sf_ext_stg_gc():
+souffle::ProgramFactory("ext_stg_gc"){
+}
+
+} // namespace  souffle
+namespace souffle {
+
+#ifdef __EMBEDDED_SOUFFLE__
+extern "C" {
+souffle::factory_Sf_ext_stg_gc __factory_Sf_ext_stg_gc_instance;
+}
+#endif
+} // namespace souffle
+

--- a/external-stg-interpreter/external-stg-interpreter.cabal
+++ b/external-stg-interpreter/external-stg-interpreter.cabal
@@ -11,6 +11,15 @@ copyright:           (c) 2020 Csaba Hruska
 category:            Development
 build-type:          Simple
 
+flag external-ext-stg-gc
+  manual:
+    True
+  default:
+    False
+  description:
+    If enabled, the ext-stg-gc binary is provided externally and available in $PATH
+    Disbled by default
+
 library
   exposed-modules:
     Foreign.LibFFI.Closure
@@ -101,17 +110,16 @@ library
                        external-stg
   default-language:    Haskell2010
 
-  include-dirs:         datalog
-
-
-  cxx-sources:          datalog/ext-stg-gc.cpp
-  cxx-options:          -D__EMBEDDED_SOUFFLE__ -D_OPENMP -std=c++17
-  if os(darwin)
-    ld-options:           "-Wl,-all_load"
-    extra-libraries:      omp stdc++
-  else
-    ld-options:           "-Wl,-u,__factory_Sf_ext_stg_gc_instance"
-    extra-libraries:      gomp
+  if !flag(external-ext-stg-gc)
+    include-dirs:         datalog
+    cxx-sources:          datalog/ext-stg-gc.cpp
+    cxx-options:          -D__EMBEDDED_SOUFFLE__ -D_OPENMP -std=c++17
+    if os(darwin)
+      ld-options:           "-Wl,-all_load"
+      extra-libraries:      omp stdc++
+    else
+      ld-options:           "-Wl,-u,__factory_Sf_ext_stg_gc_instance"
+      extra-libraries:      gomp
 
 executable ext-stg-interpreter
   default-language:    Haskell2010

--- a/external-stg-interpreter/lib/Stg/Interpreter.hs
+++ b/external-stg-interpreter/lib/Stg/Interpreter.hs
@@ -10,6 +10,7 @@ import Foreign.Ptr
 import Control.Concurrent
 import Control.Concurrent.MVar
 import qualified Control.Concurrent.Chan.Unagi.Bounded as Unagi
+import Control.Monad
 import Control.Monad.State.Strict
 import Control.Exception
 import qualified Data.Primitive.ByteArray as BA

--- a/external-stg-interpreter/lib/Stg/Interpreter/Base.hs
+++ b/external-stg-interpreter/lib/Stg/Interpreter/Base.hs
@@ -22,6 +22,7 @@ import qualified Data.ByteString.Lazy as BL
 import Data.Vector (Vector)
 import qualified Data.Primitive.ByteArray as BA
 import Control.Monad.Primitive
+import Control.Monad
 import System.Posix.DynamicLinker
 import Control.Concurrent.MVar
 import Control.Concurrent.Chan.Unagi.Bounded

--- a/external-stg-interpreter/lib/Stg/Interpreter/Debug.hs
+++ b/external-stg-interpreter/lib/Stg/Interpreter/Debug.hs
@@ -15,6 +15,7 @@ import System.Directory
 import System.FilePath
 import Text.Printf
 
+import Control.Monad
 import Control.Monad.State.Strict
 
 import Stg.Syntax

--- a/external-stg-interpreter/lib/Stg/Interpreter/Debugger.hs
+++ b/external-stg-interpreter/lib/Stg/Interpreter/Debugger.hs
@@ -2,6 +2,7 @@
 module Stg.Interpreter.Debugger where
 
 import GHC.Stack
+import Control.Monad
 import Control.Monad.State
 import qualified Data.Set as Set
 import qualified Data.Map as Map

--- a/external-stg-interpreter/lib/Stg/Interpreter/Debugger/Internal.hs
+++ b/external-stg-interpreter/lib/Stg/Interpreter/Debugger/Internal.hs
@@ -3,6 +3,7 @@ module Stg.Interpreter.Debugger.Internal where
 
 import Text.Printf
 import qualified Text.Read as Text
+import Control.Monad
 import Control.Monad.State
 import qualified Data.List as List
 import qualified Data.Set as Set

--- a/external-stg-interpreter/lib/Stg/Interpreter/Debugger/Region.hs
+++ b/external-stg-interpreter/lib/Stg/Interpreter/Debugger/Region.hs
@@ -2,6 +2,7 @@
 module Stg.Interpreter.Debugger.Region where
 
 import Text.Printf
+import Control.Monad
 import Control.Monad.State
 import Data.Maybe
 import qualified Data.List as List

--- a/external-stg-interpreter/lib/Stg/Interpreter/Debugger/Retainer.hs
+++ b/external-stg-interpreter/lib/Stg/Interpreter/Debugger/Retainer.hs
@@ -4,6 +4,7 @@ module Stg.Interpreter.Debugger.Retainer
 -- , exportRetainerDominatorTree
  ) where
 
+import Control.Monad
 import Control.Monad.Writer
 import Control.Monad.State
 import Data.Maybe

--- a/external-stg-interpreter/lib/Stg/Interpreter/Debugger/TraverseState.hs
+++ b/external-stg-interpreter/lib/Stg/Interpreter/Debugger/TraverseState.hs
@@ -6,6 +6,7 @@ module Stg.Interpreter.Debugger.TraverseState
  , getHeapObjectCategory
  ) where
 
+import Control.Monad
 import Control.Monad.State
 import Data.Set (Set)
 import qualified Data.Set as Set

--- a/external-stg-interpreter/lib/Stg/Interpreter/EmulatedLibFFI.hs
+++ b/external-stg-interpreter/lib/Stg/Interpreter/EmulatedLibFFI.hs
@@ -34,6 +34,7 @@ import Data.IntMap (IntMap)
 import qualified Data.IntMap as IntMap
 
 import GHC.Stack
+import Control.Monad
 import Control.Monad.State.Strict
 import Control.Concurrent.MVar
 

--- a/external-stg-interpreter/lib/Stg/Interpreter/FFI.hs
+++ b/external-stg-interpreter/lib/Stg/Interpreter/FFI.hs
@@ -41,6 +41,7 @@ import Data.IntMap (IntMap)
 import qualified Data.IntMap as IntMap
 
 import GHC.Stack
+import Control.Monad
 import Control.Monad.State.Strict
 import Control.Concurrent.MVar
 

--- a/external-stg-interpreter/lib/Stg/Interpreter/GC.hs
+++ b/external-stg-interpreter/lib/Stg/Interpreter/GC.hs
@@ -2,6 +2,7 @@
 module Stg.Interpreter.GC where
 
 import Text.Printf
+import Control.Monad
 import Control.Monad.State
 import qualified Data.Map as Map
 import Data.IntMap (IntMap)

--- a/external-stg-interpreter/lib/Stg/Interpreter/GC/LiveDataAnalysis.hs
+++ b/external-stg-interpreter/lib/Stg/Interpreter/GC/LiveDataAnalysis.hs
@@ -3,6 +3,7 @@
 module Stg.Interpreter.GC.LiveDataAnalysis where
 
 import GHC.Generics
+import Control.Monad
 import Control.Monad.State
 import Data.IntSet (IntSet)
 import qualified Data.IntSet as IntSet

--- a/external-stg-interpreter/lib/Stg/Interpreter/GC/RetainerAnalysis.hs
+++ b/external-stg-interpreter/lib/Stg/Interpreter/GC/RetainerAnalysis.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE RecordWildCards, LambdaCase, OverloadedStrings #-}
 module Stg.Interpreter.GC.RetainerAnalysis where
 
+import Control.Monad
 import Control.Monad.State
 import Data.Set (Set)
 import qualified Data.Set as Set

--- a/external-stg-interpreter/lib/Stg/Interpreter/IOManager.hs
+++ b/external-stg-interpreter/lib/Stg/Interpreter/IOManager.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE QuasiQuotes, TemplateHaskell #-}
 module Stg.Interpreter.IOManager where
 
+import Control.Monad
 import Control.Monad.State
 import Data.IntMap (IntMap)
 import qualified Data.IntMap as IntMap

--- a/external-stg-interpreter/lib/Stg/Interpreter/PrimOp/Addr.hs
+++ b/external-stg-interpreter/lib/Stg/Interpreter/PrimOp/Addr.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE RecordWildCards, LambdaCase, OverloadedStrings, PatternSynonyms, Strict #-}
 module Stg.Interpreter.PrimOp.Addr where
 
+import Control.Monad
 import Control.Monad.State
 import Data.Char
 import Data.Word

--- a/external-stg-interpreter/lib/Stg/Interpreter/PrimOp/ByteArray.hs
+++ b/external-stg-interpreter/lib/Stg/Interpreter/PrimOp/ByteArray.hs
@@ -8,6 +8,7 @@ import Data.Char
 import Foreign.Ptr
 import Foreign.Storable
 import Foreign.Marshal.Utils
+import Control.Monad
 import Control.Monad.State
 import qualified Data.IntMap as IntMap
 import qualified Data.Primitive.ByteArray as BA

--- a/external-stg-interpreter/lib/Stg/Interpreter/PrimOp/Concurrency.hs
+++ b/external-stg-interpreter/lib/Stg/Interpreter/PrimOp/Concurrency.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE RecordWildCards, LambdaCase, OverloadedStrings, PatternSynonyms #-}
 module Stg.Interpreter.PrimOp.Concurrency where
 
+import Control.Monad
 import Control.Monad.State
 import qualified Data.ByteString.Char8 as BS8
 import qualified Data.IntMap as IntMap

--- a/external-stg-interpreter/lib/Stg/Interpreter/PrimOp/DelayWait.hs
+++ b/external-stg-interpreter/lib/Stg/Interpreter/PrimOp/DelayWait.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE RecordWildCards, LambdaCase, OverloadedStrings, PatternSynonyms #-}
 module Stg.Interpreter.PrimOp.DelayWait where
 
+import Control.Monad
 import Control.Monad.State
 import Data.Time.Clock
 import Data.Fixed

--- a/external-stg-interpreter/lib/Stg/Interpreter/PrimOp/Double.hs
+++ b/external-stg-interpreter/lib/Stg/Interpreter/PrimOp/Double.hs
@@ -123,6 +123,6 @@ evalPrimOp fallback op args t tc = case (op, args) of
   ( "decodeDouble_Int64#", [DoubleV (D# x)]) -> do
     -- NOTE: map back to GHC primop
     let !(# a, b #) = decodeDouble_Int64# x
-    pure [Int64V (I# a), IntV (I# b)]
+    pure [Int64V (fromIntegral (I64# a)), IntV (I# b)]
 
   _ -> fallback op args t tc

--- a/external-stg-interpreter/lib/Stg/Interpreter/PrimOp/Exceptions.hs
+++ b/external-stg-interpreter/lib/Stg/Interpreter/PrimOp/Exceptions.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE RecordWildCards, LambdaCase, OverloadedStrings, PatternSynonyms #-}
 module Stg.Interpreter.PrimOp.Exceptions where
 
+import Control.Monad
 import Control.Monad.State
 
 import Stg.Syntax

--- a/external-stg-interpreter/lib/Stg/Interpreter/PrimOp/STM.hs
+++ b/external-stg-interpreter/lib/Stg/Interpreter/PrimOp/STM.hs
@@ -2,6 +2,7 @@
 module Stg.Interpreter.PrimOp.STM where
 
 import GHC.Stack
+import Control.Monad
 import Control.Monad.State
 import Data.IntMap (IntMap)
 import qualified Data.IntMap as IntMap

--- a/external-stg-interpreter/lib/Stg/Interpreter/PrimOp/WeakPointer.hs
+++ b/external-stg-interpreter/lib/Stg/Interpreter/PrimOp/WeakPointer.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE RecordWildCards, LambdaCase, OverloadedStrings, PatternSynonyms #-}
 module Stg.Interpreter.PrimOp.WeakPointer where
 
+import Control.Monad
 import Control.Monad.State
 import qualified Data.IntMap as IntMap
 import Data.Maybe

--- a/external-stg-interpreter/lib/Stg/Interpreter/Rts.hs
+++ b/external-stg-interpreter/lib/Stg/Interpreter/Rts.hs
@@ -2,6 +2,7 @@
 module Stg.Interpreter.Rts (initRtsSupport, extStgRtsSupportModule, globalStoreSymbols) where
 
 import GHC.Stack
+import Control.Monad
 import Control.Monad.State
 import Control.Concurrent.MVar
 

--- a/external-stg-interpreter/lib/Stg/Interpreter/ThreadScheduler.hs
+++ b/external-stg-interpreter/lib/Stg/Interpreter/ThreadScheduler.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE RecordWildCards, LambdaCase, OverloadedStrings, PatternSynonyms #-}
 module Stg.Interpreter.ThreadScheduler where
 
+import Control.Monad
 import Control.Monad.State
 import Data.IntMap (IntMap)
 import qualified Data.IntMap as IntMap

--- a/external-stg-interpreter/test/PrimOp/DoubleSpec.hs
+++ b/external-stg-interpreter/test/PrimOp/DoubleSpec.hs
@@ -13,6 +13,7 @@ import Stg.Syntax (Name, Type(..))
 import Stg.Interpreter.Base
 import Stg.Interpreter.PrimOp.Double
 
+import GHC.Int
 import GHC.Exts
 
 runTests :: IO ()
@@ -176,4 +177,4 @@ spec = do
     it "decodeDouble_Int64#" $
       property $ \(a :: Double) -> do
         let !(# x, y #) = decodeDouble_Int64# (unboxDouble a)
-        evalOp "decodeDouble_Int64#" [DoubleV a] `shouldReturn` [IntV (I# x), IntV (I# y)]
+        evalOp "decodeDouble_Int64#" [DoubleV a] `shouldReturn` [IntV (fromIntegral (I64# x)), IntV (I# y)]

--- a/external-stg-interpreter/test/PrimOp/WordSpec.hs
+++ b/external-stg-interpreter/test/PrimOp/WordSpec.hs
@@ -30,6 +30,9 @@ evalOp op args = do
 unboxWord :: Word -> Word#
 unboxWord (W# x) = x
 
+unboxWord64 :: Word64 -> Word64#
+unboxWord64 (W64# x) = x
+
 unboxInt :: Int -> Int#
 unboxInt (I# x) = x
 
@@ -171,7 +174,7 @@ spec = do
 
     it "popCnt64#" $
       property $ \(a :: Word) -> do
-        evalOp "popCnt64#" [WordV a] `shouldReturn` [WordV (W# (popCnt64# (unboxWord a)))]
+        evalOp "popCnt64#" [WordV a] `shouldReturn` [WordV (W# (popCnt64# (unboxWord64 (fromIntegral a))))]
 
     it "popCnt#" $
       property $ \(a :: Word) -> do
@@ -191,7 +194,9 @@ spec = do
 
     it "pdep64#" $
       property $ \(a :: Word, b :: Word) -> do
-        evalOp "pdep64#" [WordV a, WordV b] `shouldReturn` [WordV (W# (pdep64# (unboxWord a) (unboxWord b)))]
+        evalOp "pdep64#" [WordV a, WordV b] `shouldReturn` [
+          WordV $ fromIntegral (W64# (pdep64# (unboxWord64 (fromIntegral a)) (unboxWord64 (fromIntegral b))))
+          ]
 
     it "pdep#" $
       property $ \(a :: Word, b :: Word) -> do
@@ -211,7 +216,8 @@ spec = do
 
     it "pext64#" $
       property $ \(a :: Word, b :: Word) -> do
-        evalOp "pext64#" [WordV a, WordV b] `shouldReturn` [WordV (W# (pext64# (unboxWord a) (unboxWord b)))]
+        evalOp "pext64#" [WordV a, WordV b] `shouldReturn`
+          [WordV $ fromIntegral (W64# (pext64# (unboxWord64 (fromIntegral a)) (unboxWord64 (fromIntegral b))))]
 
     it "pext#" $
       property $ \(a :: Word, b :: Word) -> do
@@ -231,7 +237,7 @@ spec = do
 
     it "clz64#" $
       property $ \(a :: Word) -> do
-        evalOp "clz64#" [WordV a] `shouldReturn` [WordV (W# (clz64# (unboxWord a)))]
+        evalOp "clz64#" [WordV a] `shouldReturn` [WordV $ W# (clz64# (unboxWord64 (fromIntegral a)))]
 
     it "clz#" $
       property $ \(a :: Word) -> do
@@ -250,8 +256,8 @@ spec = do
         evalOp "ctz32#" [WordV a] `shouldReturn` [WordV (W# (ctz32# (unboxWord a)))]
 
     it "ctz64#" $
-      property $ \(a :: Word) -> do
-        evalOp "ctz64#" [WordV a] `shouldReturn` [WordV (W# (ctz64# (unboxWord a)))]
+      property $ \(a :: Word) ->
+        evalOp "ctz64#" [WordV a] `shouldReturn` [WordV (W# (ctz64# (unboxWord64 (fromIntegral a))))]
 
     it "ctz#" $
       property $ \(a :: Word) -> do
@@ -267,7 +273,7 @@ spec = do
 
     it "byteSwap64#" $
       property $ \(a :: Word) -> do
-        evalOp "byteSwap64#" [WordV a] `shouldReturn` [WordV (W# (byteSwap64# (unboxWord a)))]
+        evalOp "byteSwap64#" [WordV a] `shouldReturn` [WordV $ fromIntegral (W64# (byteSwap64# (unboxWord64 (fromIntegral a))))]
 
     it "byteSwap#" $
       property $ \(a :: Word) -> do
@@ -288,7 +294,8 @@ spec = do
 
     it "bitReverse64#" $
       property $ \(a :: Word) -> do
-        evalOp "bitReverse64#" [WordV a] `shouldReturn` [WordV (W# (bitReverse64# (unboxWord a)))]
+        evalOp "bitReverse64#" [WordV a] `shouldReturn`
+           [Word64V $ fromIntegral (W64# (bitReverse64# (unboxWord64 (fromIntegral a))))]
 
     it "bitReverse#" $
       property $ \(a :: Word) -> do

--- a/external-stg/lib/Stg/Analysis/ForeignInfo.hs
+++ b/external-stg/lib/Stg/Analysis/ForeignInfo.hs
@@ -7,11 +7,7 @@ module Stg.Analysis.ForeignInfo
   , emptyForeignInfo
   ) where
 
-import Control.Monad
 import Control.Monad.State
-
-import Data.Set (Set)
-import qualified Data.Set as Set
 
 import Data.Map (Map)
 import qualified Data.Map as Map

--- a/external-stg/lib/Stg/GHC/Symbols.hs
+++ b/external-stg/lib/Stg/GHC/Symbols.hs
@@ -1,7 +1,5 @@
 module Stg.GHC.Symbols where
 
-import Stg.Syntax
-
 liveSymbols :: [(String, String, String)]
 liveSymbols =
   -- exceptions (top level CAFs that create an Exception data constructor that can passed to raise# or raiseIO#)

--- a/lambda/src/Lambda/Stg/StripDeadCode.hs
+++ b/lambda/src/Lambda/Stg/StripDeadCode.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE LambdaCase, TupleSections, RecordWildCards, OverloadedStrings, BangPatterns #-}
 module Lambda.Stg.StripDeadCode (stripDeadCode, StripStat(..), LivenessFacts(..)) where
 
+import Control.Monad
 import Control.Monad.State
 
 import qualified Text.PrettyPrint.ANSI.Leijen as P

--- a/wpc-plugin/src/WPC/StgToExtStg.hs
+++ b/wpc-plugin/src/WPC/StgToExtStg.hs
@@ -8,6 +8,7 @@ import GHC.Prelude
 import qualified Data.ByteString.Char8 as BS8
 
 import qualified GHC
+import qualified GHC.Tc.Types.Origin    as GHC
 import qualified GHC.Hs.Extension       as GHC
 import qualified GHC.Hs.Decls           as GHC
 import qualified GHC.Builtin.PrimOps    as GHC
@@ -15,6 +16,7 @@ import qualified GHC.Core               as GHC
 import qualified GHC.Core.DataCon       as GHC
 import qualified GHC.Core.TyCon         as GHC
 import qualified GHC.Core.TyCo.Ppr      as GHC
+import qualified GHC.Core.TyCon         as GHC
 import qualified GHC.Core.TyCo.Rep      as GHC
 import qualified GHC.Core.Type          as GHC
 import qualified GHC.Data.FastString    as GHC


### PR DESCRIPTION
Hey @csabahruska,

In preparation for @mpickering and @alt-romes to [release an alpha version of `dap` integration w/ GHC](https://github.com/haskell-debugger/dap/pull/5#issuecomment-2842107968), I'd like to ensure that our work with the [haskell-estgi-debugger](https://github.com/haskell-debugger/haskell-estgi-debugger) is building along with the coming `dap` changes. 

This PR updates the `external-stg-interpreter`, `external-stg` and `external-stg-syntax` to build with GHC 9.6+.

Things done:

- [x] Adjusted primops and tests for 64-bit `Word` and `Int` since `ghc-prim` had slightly changed (primop tests pass now ✅ )
 - [x] `cabal.project` file was added and it does build with the latest `souffle-haskell-0.4.0.0` and a working version of `final-pretty`
 - [x] A cabal flag was introduced (`-fexternal-ext-stg-gc` and `-fexternal-ext-liveness-analysis` -- disabled by default in the cabal file - but enabled by default in `cabal.project`) to allow users to build the `souffle` generated C++ by hand. This simplifies the build, and `runSouffle` is able to find the `ext-stg-gc` binary in `$PATH`.
 - [x] Re-introduced `import Control.Monad`, it was decided that `Control.Monad` should no longer be re-exported from `mtl` modules.
 - [x] Adds a github workflow file. This workflow will use cabal's resolver to build the Haskell code, and nix to acquire `bzip2` and `zlib`. 
 - [x] Adds a github workflow badge to the README.md
 
 ```
     neWord16# [✔]
      +++ OK, passed 100 tests.

Finished in 0.0904 seconds
240 examples, 0 failures
Test suite primop-test: PASS
Test suite logged to:
/home/dmjio/Desktop/ghc-whole-program-compiler-project/dist-newstyle/build/x86_64-linux/ghc-9.6.6/external-stg-interpreter-0.1.0.1/t/primop-test/test/external-stg-interpreter-0.1.0.1-primop-test.log
1 of 1 test suites (1 of 1 test cases) passed.
```

^ these tests should run in CI now

Then in the `haskell-debugger` I'm able to make `ext-stg-gc` available on `PATH` so `runSouffle` will always be able to find it, when we call the `external-stg-interpreter` from `haskell-debugger`.

```nix
  ext-stg-gc =
    pkgs.stdenv.mkDerivation {
      name = "ext-stg-gc";
      src = "${ghc-wpo-src}/external-stg-interpreter";
      buildInputs = with pkgs; [ souffle openmpi ];
      buildPhase = ''
        mkdir -pv $out/bin
        g++ -fopenmp $src/datalog/ext-stg-gc.cpp \
           -D_OPENMP -std=c++17 \
           -o $out/bin/ext-stg-gc
      '';
    };
    ```